### PR TITLE
Add recursive processes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ libhst_la_SOURCES = \
 	src/libhst/operators/external-choice.c \
 	src/libhst/operators/internal-choice.c \
 	src/libhst/operators/prefix.c \
+	src/libhst/operators/recursion.c \
 	src/libhst/operators/sequential-composition.c \
 	third_party/ccan/build_assert/build_assert.h \
 	third_party/ccan/compiler/compiler.h \

--- a/include/hst.h
+++ b/include/hst.h
@@ -222,13 +222,16 @@ struct csp_process_iface {
  * is already an existing process with the same ID, then we do nothing else and
  * return the ID of the existing process.
  *
- * If the process is new, then we need to turn the "tempoary" userdata into a
+ * If the process is new, then we need to turn the "temporary" userdata into a
  * "permanent" one.  To do this, we'll first call the process's `ud_size`
  * callback, which should return the size of the permanent userdata.  We'll then
  * allocate this much memory, and call the process's `init_ud` callback to fill
- * it in from the temporary userdata. */
+ * it in from the temporary userdata.
+ *
+ * If `ud` is non-NULL, we will fill it in with a pointer to the permanent
+ * userdata that we create for you. */
 csp_id
-csp_process_init(struct csp *csp, const void *temp_ud,
+csp_process_init(struct csp *csp, const void *temp_ud, void **ud,
                  const struct csp_process_iface *iface);
 
 void
@@ -292,6 +295,9 @@ csp_id_add_id_set(csp_id id, const struct csp_id_set *set);
 csp_id
 csp_id_add_name(csp_id id, const char *name);
 
+csp_id
+csp_id_add_name_sized(csp_id id, const char *name, size_t name_length);
+
 /*------------------------------------------------------------------------------
  * Operators
  */
@@ -316,6 +322,61 @@ csp_replicated_internal_choice(struct csp *csp, const struct csp_id_set *ps);
 
 csp_id
 csp_sequential_composition(struct csp *csp, csp_id p, csp_id q);
+
+/*------------------------------------------------------------------------------
+ * Recursion
+ */
+
+/* A "recursion scope" is the main building block that you need to create
+ * mutually recursive processes.  You can create one or more "recursion targets"
+ * within the scope, each of which maps a name to a process.  But importantly,
+ * you don't have to know in advance which process you're going to map each name
+ * to.  That lets you define a name for a process, and then use that same name
+ * in the definition of the process.  Presto, recursion! */
+
+struct csp_recursion_scope {
+    csp_id  scope;
+    size_t  unfilled_count;
+    void  *names;
+};
+
+/* Initialize a new recursion scope.  You are responsible for passing in a
+ * different `scope_id` for each recursion scope that you create. */
+void
+csp_recursion_scope_init(struct csp *csp, struct csp_recursion_scope *scope);
+
+void
+csp_recursion_scope_done(struct csp_recursion_scope *scope);
+
+/* Return the process ID of the recursion target with the given name, creating
+ * it if necessary.  The recursion target will initially be empty; you must
+ * "fill" it by calling csp_recursion_scope_fill before destroying the scope. */
+csp_id
+csp_recursion_scope_get(struct csp *csp, struct csp_recursion_scope *scope,
+                        const char *name);
+
+/* Same as csp_recursion_scope_add, but providing an explicit length for `name`.
+ * `name` does not need to be NUL-terminated, but it cannot contain any NULs. */
+csp_id
+csp_recursion_scope_get_sized(struct csp *csp,
+                              struct csp_recursion_scope *scope,
+                              const char *name, size_t name_length);
+
+/* Fill a recursion target.  You must call this exactly once for each recursion
+ * target that you create.  Returns false if this recursion target doesn't
+ * exist, or if it has been filled already.  After this function returns, the
+ * recursion target will behave exactly like `process`. */
+bool
+csp_recursion_scope_fill(struct csp_recursion_scope *scope, const char *name,
+                         csp_id process);
+
+/* Same as csp_recursion_scope_fill, but providing an explicit length for
+ * `name`.  `name` does not need to be NUL-terminated, but it cannot contain any
+ * NULs. */
+bool
+csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
+                               const char *name, size_t name_length,
+                               csp_id process);
 
 /*------------------------------------------------------------------------------
  * CSP₀

--- a/include/hst.h
+++ b/include/hst.h
@@ -55,32 +55,6 @@ csp_get_sized_event_id(struct csp *csp, const char *name, size_t name_length);
 const char *
 csp_get_event_name(struct csp *csp, csp_id event);
 
-/* Add a name for an existing process.  Not every process will have a name, and
- * each process might have more than one name.  Returns false if there is
- * already a process with the given name. */
-bool
-csp_add_process_name(struct csp *csp, csp_id process, const char *name);
-
-/* Add a name for an existing process.  `name` does not need to be
- * NUL-terminated, but it cannot contain any NULs.  Not every process will have
- * a name, and each process might have more than one name.  Returns false if
- * there is already a process with the given name. */
-bool
-csp_add_process_sized_name(struct csp *csp, csp_id process, const char *name,
-                           size_t name_length);
-
-/* Return the ID of the process with the given name.  Returns `CSP_PROCESS_NONE`
- * if there is no process with that name. */
-csp_id
-csp_get_process_by_name(struct csp *csp, const char *name);
-
-/* Return the ID of the process with the given name.  `name` does not need to be
- * NUL-terminated, but it cannot contain any NULs.  Returns `CSP_PROCESS_NONE`
- * if there is no process with that name. */
-csp_id
-csp_get_process_by_sized_name(struct csp *csp, const char *name,
-                              size_t name_length);
-
 /*------------------------------------------------------------------------------
  * Sets
  */

--- a/src/libhst/environment.c
+++ b/src/libhst/environment.c
@@ -59,7 +59,6 @@ struct csp_priv {
     struct csp  public;
     void  *events;
     void  *processes;
-    void  *process_names;
     struct csp_process  *stop;
     struct csp_process  *skip;
 };
@@ -174,14 +173,11 @@ csp_new(void)
     }
     csp->events = NULL;
     csp->processes = NULL;
-    csp->process_names = NULL;
     csp->public.tau = csp_get_event_id(&csp->public, TAU);
     csp->public.tick = csp_get_event_id(&csp->public, TICK);
     csp->public.stop = csp_process_init(&csp->public, NULL, &csp_stop_iface);
-    csp_add_process_name(&csp->public, csp->public.stop, "STOP");
     csp->stop = csp_process_get(csp, csp->public.stop);
     csp->public.skip = csp_process_init(&csp->public, NULL, &csp_skip_iface);
-    csp_add_process_name(&csp->public, csp->public.skip, "SKIP");
     csp->skip = csp_process_get(csp, csp->public.skip);
     return &csp->public;
 }
@@ -191,8 +187,6 @@ csp_free(struct csp *pcsp)
 {
     struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
     UNNEEDED Word_t  dummy;
-
-    JHSFA(dummy, csp->process_names);
 
     {
         Word_t  *vname;
@@ -261,47 +255,6 @@ csp_get_event_name(struct csp *pcsp, csp_id event)
         return NULL;
     } else {
         return (void *) *vname;
-    }
-}
-
-bool
-csp_add_process_name(struct csp *csp, csp_id process, const char *name)
-{
-    return csp_add_process_sized_name(csp, process, name, strlen(name));
-}
-
-bool
-csp_add_process_sized_name(struct csp *pcsp, csp_id process, const char *name,
-                           size_t name_length)
-{
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    Word_t  *vprocess;
-    JHSI(vprocess, csp->process_names, (uint8_t *) name, name_length);
-    if (*vprocess == 0) {
-        *vprocess = process;
-        return true;
-    } else {
-        return false;
-    }
-}
-
-csp_id
-csp_get_process_by_name(struct csp *csp, const char *name)
-{
-    return csp_get_process_by_sized_name(csp, name, strlen(name));
-}
-
-csp_id
-csp_get_process_by_sized_name(struct csp *pcsp, const char *name,
-                              size_t name_length)
-{
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    Word_t  *vprocess;
-    JHSG(vprocess, csp->process_names, (uint8_t *) name, name_length);
-    if (vprocess == NULL) {
-        return CSP_PROCESS_NONE;
-    } else {
-        return *vprocess;
     }
 }
 

--- a/src/libhst/operators/external-choice.c
+++ b/src/libhst/operators/external-choice.c
@@ -143,7 +143,7 @@ csp_external_choice_done(struct csp *csp, void *vchoice)
     csp_id_set_done(&choice->ps);
 }
 
-const struct csp_process_iface  csp_external_choice_iface = {
+static const struct csp_process_iface  csp_external_choice_iface = {
     &csp_external_choice_initials,
     &csp_external_choice_afters,
     &csp_external_choice_get_id,
@@ -159,7 +159,7 @@ csp_external_choice(struct csp *csp, csp_id a, csp_id b)
     struct csp_id_set  ps;
     csp_id_set_init(&ps);
     csp_id_set_fill_double(&ps, a, b);
-    id = csp_process_init(csp, &ps, &csp_external_choice_iface);
+    id = csp_process_init(csp, &ps, NULL, &csp_external_choice_iface);
     csp_id_set_done(&ps);
     return id;
 }
@@ -167,5 +167,5 @@ csp_external_choice(struct csp *csp, csp_id a, csp_id b)
 csp_id
 csp_replicated_external_choice(struct csp *csp, const struct csp_id_set *ps)
 {
-    return csp_process_init(csp, ps, &csp_external_choice_iface);
+    return csp_process_init(csp, ps, NULL, &csp_external_choice_iface);
 }

--- a/src/libhst/operators/internal-choice.c
+++ b/src/libhst/operators/internal-choice.c
@@ -72,7 +72,7 @@ csp_internal_choice_done(struct csp *csp, void *vchoice)
     csp_id_set_done(&choice->ps);
 }
 
-const struct csp_process_iface  csp_internal_choice_iface = {
+static const struct csp_process_iface  csp_internal_choice_iface = {
     &csp_internal_choice_initials,
     &csp_internal_choice_afters,
     &csp_internal_choice_get_id,
@@ -88,7 +88,7 @@ csp_internal_choice(struct csp *csp, csp_id a, csp_id b)
     struct csp_id_set  ps;
     csp_id_set_init(&ps);
     csp_id_set_fill_double(&ps, a, b);
-    id = csp_process_init(csp, &ps, &csp_internal_choice_iface);
+    id = csp_process_init(csp, &ps, NULL, &csp_internal_choice_iface);
     csp_id_set_done(&ps);
     return id;
 }
@@ -96,5 +96,5 @@ csp_internal_choice(struct csp *csp, csp_id a, csp_id b)
 csp_id
 csp_replicated_internal_choice(struct csp *csp, const struct csp_id_set *ps)
 {
-    return csp_process_init(csp, ps, &csp_internal_choice_iface);
+    return csp_process_init(csp, ps, NULL, &csp_internal_choice_iface);
 }

--- a/src/libhst/operators/prefix.c
+++ b/src/libhst/operators/prefix.c
@@ -73,7 +73,7 @@ csp_prefix_done(struct csp *csp, void *vprefix)
     /* nothing to do */
 }
 
-const struct csp_process_iface  csp_prefix_iface = {
+static const struct csp_process_iface  csp_prefix_iface = {
     &csp_prefix_initials,
     &csp_prefix_afters,
     &csp_prefix_get_id,
@@ -86,5 +86,5 @@ csp_id
 csp_prefix(struct csp *csp, csp_id a, csp_id p)
 {
     struct csp_prefix  input = { a, p };
-    return csp_process_init(csp, &input, &csp_prefix_iface);
+    return csp_process_init(csp, &input, NULL, &csp_prefix_iface);
 }

--- a/src/libhst/operators/recursion.c
+++ b/src/libhst/operators/recursion.c
@@ -103,8 +103,11 @@ csp_recursion(struct csp *csp, csp_id id, struct csp_recursion **recursion)
     csp_process_init(csp, &id, (void **) recursion, &csp_recursion_iface);
 }
 
-static csp_id
-csp_recursion_create_id(csp_id scope, const char *name, size_t name_length)
+/* The double-underscore will cause the linker to not expose this as a public
+ * part of the API, but we can still use it in other files.  We use this is the
+ * CSP₀ to support the (somewhat-hacky, testing-only) X@0 syntax. */
+csp_id
+csp__recursion_create_id(csp_id scope, const char *name, size_t name_length)
 {
     static struct csp_id_scope  recursion;
     csp_id  id = csp_id_start(&recursion);
@@ -126,7 +129,7 @@ csp_recursion_scope_get_sized(struct csp *csp,
                               const char *name, size_t name_length)
 {
     Word_t  *vrecursion;
-    csp_id  id = csp_recursion_create_id(scope->scope, name, name_length);
+    csp_id  id = csp__recursion_create_id(scope->scope, name, name_length);
     JLI(vrecursion, scope->names, id);
     if (*vrecursion == 0) {
         struct csp_recursion  *recursion = NULL;
@@ -150,7 +153,7 @@ csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
                                csp_id process)
 {
     Word_t  *vrecursion;
-    csp_id  id = csp_recursion_create_id(scope->scope, name, name_length);
+    csp_id  id = csp__recursion_create_id(scope->scope, name, name_length);
     JLG(vrecursion, scope->names, id);
     if (unlikely(vrecursion == NULL)) {
         return false;

--- a/src/libhst/operators/recursion.c
+++ b/src/libhst/operators/recursion.c
@@ -1,0 +1,167 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define JUDYERROR_NOTEST 1
+#include <Judy.h>
+
+#include "ccan/compiler/compiler.h"
+#include "ccan/container_of/container_of.h"
+#include "ccan/hash/hash.h"
+#include "ccan/likely/likely.h"
+#include "hst.h"
+
+struct csp_priv {
+    struct csp  public;
+    csp_id  next_recursion_scope_id;
+};
+
+void
+csp_recursion_scope_init(struct csp *pcsp, struct csp_recursion_scope *scope)
+{
+    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
+    scope->scope = csp->next_recursion_scope_id++;
+    scope->unfilled_count = 0;
+    scope->names = NULL;
+}
+
+void
+csp_recursion_scope_done(struct csp_recursion_scope *scope)
+{
+    UNNEEDED Word_t  dummy;
+    JLFA(dummy, scope->names);
+}
+
+struct csp_recursion {
+    csp_id  process;
+};
+
+static void
+csp_recursion_initials(struct csp *csp, struct csp_id_set_builder *builder,
+                       void *vrecursion)
+{
+    struct csp_recursion  *recursion = vrecursion;
+    assert(recursion->process != CSP_PROCESS_NONE);
+    csp_process_build_initials(csp, recursion->process, builder);
+}
+
+static void
+csp_recursion_afters(struct csp *csp, csp_id initial,
+                     struct csp_id_set_builder *builder, void *vrecursion)
+{
+    struct csp_recursion  *recursion = vrecursion;
+    assert(recursion->process != CSP_PROCESS_NONE);
+    csp_process_build_afters(csp, recursion->process, initial, builder);
+}
+
+static csp_id
+csp_recursion_get_id(struct csp *csp, const void *vinput)
+{
+    const csp_id  *input = vinput;
+    return *input;
+}
+
+static size_t
+csp_recursion_ud_size(struct csp *csp, const void *vinput)
+{
+    return sizeof(struct csp_recursion);
+}
+
+static void
+csp_recursion_init(struct csp *csp, void *vrecursion, const void *vinput)
+{
+    struct csp_recursion  *recursion = vrecursion;
+    recursion->process = CSP_PROCESS_NONE;
+}
+
+static void
+csp_recursion_done(struct csp *csp, void *vrecursion)
+{
+    /* nothing to do */
+}
+
+static const struct csp_process_iface  csp_recursion_iface = {
+    &csp_recursion_initials,
+    &csp_recursion_afters,
+    &csp_recursion_get_id,
+    &csp_recursion_ud_size,
+    &csp_recursion_init,
+    &csp_recursion_done
+};
+
+static void
+csp_recursion(struct csp *csp, csp_id id, struct csp_recursion **recursion)
+{
+    csp_process_init(csp, &id, (void **) recursion, &csp_recursion_iface);
+}
+
+static csp_id
+csp_recursion_create_id(csp_id scope, const char *name, size_t name_length)
+{
+    static struct csp_id_scope  recursion;
+    csp_id  id = csp_id_start(&recursion);
+    id = csp_id_add_id(id, scope);
+    id = csp_id_add_name_sized(id, name, name_length);
+    return id;
+}
+
+csp_id
+csp_recursion_scope_get(struct csp *csp, struct csp_recursion_scope *scope,
+                        const char *name)
+{
+    return csp_recursion_scope_get_sized(csp, scope, name, strlen(name));
+}
+
+csp_id
+csp_recursion_scope_get_sized(struct csp *csp,
+                              struct csp_recursion_scope *scope,
+                              const char *name, size_t name_length)
+{
+    Word_t  *vrecursion;
+    csp_id  id = csp_recursion_create_id(scope->scope, name, name_length);
+    JLI(vrecursion, scope->names, id);
+    if (*vrecursion == 0) {
+        struct csp_recursion  *recursion = NULL;
+        csp_recursion(csp, id, &recursion);
+        *vrecursion = (Word_t) recursion;
+        scope->unfilled_count++;
+    }
+    return id;
+}
+
+bool
+csp_recursion_scope_fill(struct csp_recursion_scope *scope, const char *name,
+                         csp_id process)
+{
+    return csp_recursion_scope_fill_sized(scope, name, strlen(name), process);
+}
+
+bool
+csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
+                               const char *name, size_t name_length,
+                               csp_id process)
+{
+    Word_t  *vrecursion;
+    csp_id  id = csp_recursion_create_id(scope->scope, name, name_length);
+    JLG(vrecursion, scope->names, id);
+    if (unlikely(vrecursion == NULL)) {
+        return false;
+    } else {
+        struct csp_recursion  *recursion = (void *) *vrecursion;
+        if (likely(recursion->process == CSP_PROCESS_NONE)) {
+            scope->unfilled_count--;
+            recursion->process = process;
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/libhst/operators/sequential-composition.c
+++ b/src/libhst/operators/sequential-composition.c
@@ -127,7 +127,7 @@ csp_sequential_composition_done(struct csp *csp, void *vseq)
     /* nothing to do */
 }
 
-const struct csp_process_iface  csp_sequential_composition_iface = {
+static const struct csp_process_iface  csp_sequential_composition_iface = {
     &csp_sequential_composition_initials,
     &csp_sequential_composition_afters,
     &csp_sequential_composition_get_id,
@@ -140,5 +140,6 @@ csp_id
 csp_sequential_composition(struct csp *csp, csp_id p, csp_id q)
 {
     struct csp_sequential_composition  input = { p, q };
-    return csp_process_init(csp, &input, &csp_sequential_composition_iface);
+    return csp_process_init(
+            csp, &input, NULL, &csp_sequential_composition_iface);
 }

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -215,7 +215,8 @@ exit_status(void)
 
 #define check_with_msg(call, ...) \
     do { \
-        if (unlikely(!(call))) { \
+        bool  __result = (call); \
+        if (unlikely(!__result)) { \
             fail_at(__FILE__, __LINE__, __VA_ARGS__); \
             return; \
         } \
@@ -225,7 +226,8 @@ exit_status(void)
 
 #define check0_with_msg(call, ...) \
     do { \
-        if (unlikely((call) != 0)) { \
+        int  __rc = (call); \
+        if (unlikely(__rc != 0)) { \
             fail_at(__FILE__, __LINE__, __VA_ARGS__); \
             return; \
         } \
@@ -235,7 +237,8 @@ exit_status(void)
 
 #define checkx0_with_msg(call, ...) \
     do { \
-        if (unlikely((call) == 0)) { \
+        int  __rc = (call); \
+        if (unlikely(__rc == 0)) { \
             fail_at(__FILE__, __LINE__, __VA_ARGS__); \
             return; \
         } \
@@ -245,7 +248,8 @@ exit_status(void)
 
 #define check_nonnull_with_msg(call, ...) \
     do { \
-        if (unlikely((call) == NULL)) { \
+        void  *__result = (call); \
+        if (unlikely(__result == NULL)) { \
             fail_at(__FILE__, __LINE__, __VA_ARGS__); \
             return; \
         } \

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -70,7 +70,7 @@ TEST_CASE("can parse identifiers") {
 
 TEST_CASE_GROUP("CSP₀ primitives");
 
-TEST_CASE("can parse STOP") {
+TEST_CASE("parse: STOP") {
     struct csp  *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
@@ -83,7 +83,7 @@ TEST_CASE("can parse STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse SKIP") {
+TEST_CASE("parse: SKIP") {
     struct csp  *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
@@ -98,7 +98,7 @@ TEST_CASE("can parse SKIP") {
 
 TEST_CASE_GROUP("CSP₀ operators");
 
-TEST_CASE("can parse external choice") {
+TEST_CASE("parse: a → STOP □ SKIP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  p1;
@@ -131,7 +131,7 @@ TEST_CASE("can parse external choice") {
     csp_free(csp);
 }
 
-TEST_CASE("external choice is right-associative") {
+TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;
@@ -158,7 +158,7 @@ TEST_CASE("external choice is right-associative") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse internal choice") {
+TEST_CASE("parse: a → STOP ⊓ SKIP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  p1;
@@ -191,7 +191,7 @@ TEST_CASE("can parse internal choice") {
     csp_free(csp);
 }
 
-TEST_CASE("internal choice is right-associative") {
+TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;
@@ -218,7 +218,7 @@ TEST_CASE("internal choice is right-associative") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse parentheses") {
+TEST_CASE("parse: (STOP)") {
     struct csp  *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
@@ -234,7 +234,7 @@ TEST_CASE("can parse parentheses") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse prefix") {
+TEST_CASE("parse: a → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  root;
@@ -264,7 +264,7 @@ TEST_CASE("can parse prefix") {
     csp_free(csp);
 }
 
-TEST_CASE("prefix is right-associative") {
+TEST_CASE("associativity: a → b → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;
@@ -283,7 +283,7 @@ TEST_CASE("prefix is right-associative") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse replicated external choice") {
+TEST_CASE("parse: □ {a → STOP, SKIP}") {
     struct csp  *csp;
     csp_id  a;
     csp_id  p1;
@@ -329,7 +329,7 @@ TEST_CASE("can parse replicated external choice") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse replicated internal choice") {
+TEST_CASE("parse: ⊓ {a → STOP, SKIP}") {
     struct csp  *csp;
     csp_id  a;
     csp_id  p1;
@@ -375,7 +375,7 @@ TEST_CASE("can parse replicated internal choice") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse sequential composition") {
+TEST_CASE("parse: a → SKIP ; STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  p1;
@@ -405,7 +405,7 @@ TEST_CASE("can parse sequential composition") {
     csp_free(csp);
 }
 
-TEST_CASE("sequential composition is right-associative") {
+TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;
@@ -431,7 +431,7 @@ TEST_CASE("sequential composition is right-associative") {
     csp_free(csp);
 }
 
-TEST_CASE("verify precedence of a → STOP □ b → STOP ⊓ c → STOP") {
+TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;
@@ -460,7 +460,7 @@ TEST_CASE("verify precedence of a → STOP □ b → STOP ⊓ c → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("verify precedence of a → STOP □ b → SKIP ; c → STOP") {
+TEST_CASE("precedence: a → STOP □ b → SKIP ; c → STOP") {
     struct csp  *csp;
     csp_id  a;
     csp_id  b;

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -68,6 +68,22 @@ TEST_CASE("can parse identifiers") {
     csp_free(csp);
 }
 
+TEST_CASE("can parse debug recursion identifiers") {
+    struct csp  *csp;
+    /* Create the CSP environment. */
+    check_alloc(csp, csp_new());
+    /* Parse a bunch of valid identifiers. */
+    check_csp0_valid("a → X@0");
+    check_csp0_valid("a → X@1");
+    check_csp0_valid("a → X@10");
+    check_csp0_valid("a → X@010");
+    /* Fail to parse a bunch of invalid identifiers. */
+    check_csp0_invalid("a → X@");
+    check_csp0_invalid("a → X@X");
+    /* Clean up. */
+    csp_free(csp);
+}
+
 TEST_CASE_GROUP("CSP₀ primitives");
 
 TEST_CASE("parse: STOP") {

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -283,6 +283,47 @@ TEST_CASE("associativity: a → b → STOP") {
     csp_free(csp);
 }
 
+TEST_CASE("parse: let X = a → STOP within X") {
+    struct csp  *csp;
+    /* Create the CSP environment. */
+    check_alloc(csp, csp_new());
+    /* Verify that we can parse the process, with and without whitespace. */
+    check_csp0_valid("let X=a→STOP within X");
+    check_csp0_valid(" let X=a→STOP within X");
+    check_csp0_valid(" let X =a→STOP within X");
+    check_csp0_valid(" let X = a→STOP within X");
+    check_csp0_valid(" let X = a →STOP within X");
+    check_csp0_valid(" let X = a → STOP within X");
+    check_csp0_valid(" let X = a → STOP within X ");
+    /* Fail to parse a bunch of invalid statements. */
+    /* missing process definition */
+    check_csp0_invalid("let within X");
+    /* undefined process */
+    check_csp0_invalid("let X = a → Y within X");
+    /* Clean up. */
+    csp_free(csp);
+}
+
+TEST_CASE("parse: let X = a → Y Y = b → X within X") {
+    struct csp  *csp;
+    /* Create the CSP environment. */
+    check_alloc(csp, csp_new());
+    /* Verify that we can parse the process, with and without whitespace. */
+    check_csp0_valid("let X=a→Y Y=b→X within X");
+    check_csp0_valid(" let X=a→Y Y=b→X within X");
+    check_csp0_valid(" let X =a→Y Y=b→X within X");
+    check_csp0_valid(" let X = a→Y Y=b→X within X");
+    check_csp0_valid(" let X = a →Y Y=b→X within X");
+    check_csp0_valid(" let X = a → Y Y=b→X within X");
+    check_csp0_valid(" let X = a → Y Y =b→X within X");
+    check_csp0_valid(" let X = a → Y Y = b→X within X");
+    check_csp0_valid(" let X = a → Y Y = b →X within X");
+    check_csp0_valid(" let X = a → Y Y = b → X within X");
+    check_csp0_valid(" let X = a → Y Y = b → X within X ");
+    /* Clean up. */
+    csp_free(csp);
+}
+
 TEST_CASE("parse: □ {a → STOP, SKIP}") {
     struct csp  *csp;
     csp_id  a;

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -11,18 +11,6 @@
 #include "test-cases.h"
 #include "test-case-harness.h"
 
-#define check_named_process_eq(name, expected) \
-    do { \
-        csp_id  __actual = csp_get_process_by_name(csp, (name)); \
-        check_id_eq(__actual, (expected)); \
-    } while (0)
-
-#define check_sized_named_process_eq(name, len, expected) \
-    do { \
-        csp_id  __actual = csp_get_process_by_sized_name(csp, (name), (len)); \
-        check_id_eq(__actual, (expected)); \
-    } while (0)
-
 #define build_set(set, ...) \
     do { \
         csp_id  __to_add[] = { __VA_ARGS__ }; \
@@ -68,9 +56,6 @@ TEST_CASE("predefined STOP process exists") {
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
     check_alloc(csp, csp_new());
-    /* Verify that STOP has the right name. */
-    check_named_process_eq("STOP", csp->stop);
-    check_sized_named_process_eq("STOP", 4, csp->stop);
     /* Verify the initials set of the STOP process. */
     csp_process_build_initials(csp, csp->stop, &builder);
     csp_id_set_build(&set, &builder);
@@ -97,9 +82,6 @@ TEST_CASE("predefined SKIP process exists") {
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
     check_alloc(csp, csp_new());
-    /* Verify that SKIP has the right name. */
-    check_named_process_eq("SKIP", csp->skip);
-    check_sized_named_process_eq("SKIP", 4, csp->skip);
     /* Verify the initials set of the SKIP process. */
     csp_process_build_initials(csp, csp->skip, &builder);
     csp_id_set_build(&set, &builder);
@@ -115,48 +97,6 @@ TEST_CASE("predefined SKIP process exists") {
     /* Clean up. */
     csp_id_set_builder_done(&builder);
     csp_id_set_done(&set);
-    csp_free(csp);
-}
-
-TEST_CASE("can add new process names") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* Create a couple of new process names. */
-    check(csp_add_process_name(csp, csp->stop, "a"));
-    check(csp_add_process_sized_name(csp, csp->skip, "b", 1));
-    /* And verify that they map to the process IDs that we gave. */
-    check_named_process_eq("a", csp->stop);
-    check_named_process_eq("b", csp->skip);
-    check_sized_named_process_eq("a", 1, csp->stop);
-    check_sized_named_process_eq("b", 1, csp->skip);
-    /* Clean up. */
-    csp_free(csp);
-}
-
-TEST_CASE("can detect undefined process names") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* And verify that we get a "no process" ID for an undefined name. */
-    check_named_process_eq("a", CSP_PROCESS_NONE);
-    check_sized_named_process_eq("a", 1, CSP_PROCESS_NONE);
-    /* Clean up. */
-    csp_free(csp);
-}
-
-TEST_CASE("cannot overwrite process names") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* Create a new process name. */
-    check(csp_add_process_name(csp, csp->stop, "a"));
-    /* Try to overwrite it; verify that this fails. */
-    check(!csp_add_process_name(csp, csp->skip, "a"));
-    /* And verify that the name maps to the original ID. */
-    check_named_process_eq("a", csp->stop);
-    check_sized_named_process_eq("a", 1, csp->stop);
-    /* Clean up. */
     csp_free(csp);
 }
 

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -192,6 +192,29 @@ TEST_CASE("a → b → STOP") {
     csp_free(csp);
 }
 
+TEST_CASE_GROUP("recursion");
+
+TEST_CASE("let X=a → STOP within X") {
+    struct csp  *csp;
+    /* Create the CSP environment. */
+    check_alloc(csp, csp_new());
+    /* STOP □ STOP */
+    check_csp0_initials("let X=a → STOP within X", ("a"));
+    check_csp0_afters("let X=a → STOP within X", "a", ("STOP"));
+    /* Clean up. */
+    csp_free(csp);
+}
+
+TEST_CASE("let X=a → Y Y=b → X within X") {
+    struct csp  *csp;
+    /* Create the CSP environment. */
+    check_alloc(csp, csp_new());
+    /* STOP □ STOP */
+    check_csp0_initials("let X=a → Y Y=b → X within X", ("a"));
+    /* Clean up. */
+    csp_free(csp);
+}
+
 TEST_CASE_GROUP("sequential composition");
 
 TEST_CASE("SKIP ; STOP") {

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -24,10 +24,12 @@
  * (possibly empty) parenthesized list of event names. */
 #define check_csp0_initials(csp0, events) \
     do { \
+        struct csp  *csp; \
         csp_id  __process; \
         struct csp_id_set_builder  __builder; \
         struct csp_id_set  __actual; \
         struct csp_id_set  __expected; \
+        check_alloc(csp, csp_new()); \
         csp_id_set_builder_init(&__builder); \
         csp_id_set_init(&__actual); \
         csp_id_set_init(&__expected); \
@@ -43,6 +45,7 @@
         csp_id_set_builder_done(&__builder); \
         csp_id_set_done(&__actual); \
         csp_id_set_done(&__expected); \
+        csp_free(csp); \
     } while (0)
 
 /* Verify the `afters` of the given CSP₀ process after performing `initial`.
@@ -50,11 +53,13 @@
  * parenthesized list of CSP₀ processes. */
 #define check_csp0_afters(csp0, initial, afters) \
     do { \
+        struct csp  *csp; \
         csp_id  __process; \
         csp_id  __initial; \
         struct csp_id_set_builder  __builder; \
         struct csp_id_set  __actual; \
         struct csp_id_set  __expected; \
+        check_alloc(csp, csp_new()); \
         csp_id_set_builder_init(&__builder); \
         csp_id_set_init(&__actual); \
         csp_id_set_init(&__expected); \
@@ -71,205 +76,116 @@
         csp_id_set_builder_done(&__builder); \
         csp_id_set_done(&__actual); \
         csp_id_set_done(&__expected); \
+        csp_free(csp); \
     } while (0)
 
 TEST_CASE_GROUP("external choice");
 
 TEST_CASE("STOP □ STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* STOP □ STOP */
     check_csp0_initials("STOP □ STOP", ());
     check_csp0_afters("STOP □ STOP", "a", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* (a → STOP) □ (b → STOP ⊓ c → STOP) */
     check_csp0_initials("(a → STOP) □ (b → STOP ⊓ c → STOP)", ("a", "τ"));
     check_csp0_afters("(a → STOP) □ (b → STOP ⊓ c → STOP)", "a", ("STOP"));
     check_csp0_afters("(a → STOP) □ (b → STOP ⊓ c → STOP)", "b", ());
     check_csp0_afters("(a → STOP) □ (b → STOP ⊓ c → STOP)", "τ",
                       ("a → STOP □ b → STOP", "a → STOP □ c → STOP"));
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("(a → STOP) □ (b → STOP)") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* (a → STOP) □ (b → STOP) */
     check_csp0_initials("(a → STOP) □ (b → STOP)", ("a", "b"));
     check_csp0_afters("(a → STOP) □ (b → STOP)", "a", ("STOP"));
     check_csp0_afters("(a → STOP) □ (b → STOP)", "b", ("STOP"));
     check_csp0_afters("(a → STOP) □ (b → STOP)", "τ", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("□ {a → STOP, b → STOP, c → STOP}") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* □ {a → STOP, b → STOP, c → STOP} */
     check_csp0_initials("□ {a → STOP, b → STOP, c → STOP}", ("a", "b", "c"));
     check_csp0_afters("□ {a → STOP, b → STOP, c → STOP}", "a", ("STOP"));
     check_csp0_afters("□ {a → STOP, b → STOP, c → STOP}", "b", ("STOP"));
     check_csp0_afters("□ {a → STOP, b → STOP, c → STOP}", "c", ("STOP"));
     check_csp0_afters("□ {a → STOP, b → STOP, c → STOP}", "τ", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE_GROUP("internal choice");
 
 TEST_CASE("STOP ⊓ STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* STOP ⊓ STOP */
     check_csp0_initials("STOP ⊓ STOP", ("τ"));
     check_csp0_afters("STOP ⊓ STOP", "τ", ("STOP"));
     check_csp0_afters("STOP ⊓ STOP", "a", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("(a → STOP) ⊓ (b → STOP)") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* (a → STOP) ⊓ (b → STOP) */
     check_csp0_initials("(a → STOP) ⊓ (b → STOP)", ("τ"));
     check_csp0_afters("(a → STOP) ⊓ (b → STOP)", "τ", ("a → STOP", "b → STOP"));
     check_csp0_afters("(a → STOP) ⊓ (b → STOP)", "a", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* ⊓ {a → STOP, b → STOP, c → STOP} */
     check_csp0_initials("⊓ {a → STOP, b → STOP, c → STOP}", ("τ"));
     check_csp0_afters("⊓ {a → STOP, b → STOP, c → STOP}", "τ",
                       ("a → STOP", "b → STOP", "c → STOP"));
     check_csp0_afters("⊓ {a → STOP, b → STOP, c → STOP}", "a", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE_GROUP("prefix");
 
 TEST_CASE("a → STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → STOP */
     check_csp0_initials("a → STOP", ("a"));
     check_csp0_afters("a → STOP", "a", ("STOP"));
     check_csp0_afters("a → STOP", "b", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("a → b → STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → b → STOP */
     check_csp0_initials("a → b → STOP", ("a"));
     check_csp0_afters("a → b → STOP", "a", ("b → STOP"));
     check_csp0_afters("a → b → STOP", "b", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE_GROUP("recursion");
 
 TEST_CASE("let X=a → STOP within X") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* STOP □ STOP */
     check_csp0_initials("let X=a → STOP within X", ("a"));
     check_csp0_afters("let X=a → STOP within X", "a", ("STOP"));
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("let X=a → Y Y=b → X within X") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* STOP □ STOP */
     check_csp0_initials("let X=a → Y Y=b → X within X", ("a"));
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE_GROUP("sequential composition");
 
 TEST_CASE("SKIP ; STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → STOP */
     check_csp0_initials("SKIP ; STOP", ("τ"));
     check_csp0_afters("SKIP ; STOP", "a", ());
     check_csp0_afters("SKIP ; STOP", "b", ());
     check_csp0_afters("SKIP ; STOP", "τ", ("STOP"));
     check_csp0_afters("SKIP ; STOP", "✔", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("a → SKIP ; STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → STOP */
     check_csp0_initials("a → SKIP ; STOP", ("a"));
     check_csp0_afters("a → SKIP ; STOP", "a", ("SKIP ; STOP"));
     check_csp0_afters("a → SKIP ; STOP", "b", ());
     check_csp0_afters("a → SKIP ; STOP", "τ", ());
     check_csp0_afters("a → SKIP ; STOP", "✔", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("(a → b → STOP □ SKIP) ; STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → STOP */
     check_csp0_initials("(a → b → STOP □ SKIP) ; STOP", ("a", "τ"));
     check_csp0_afters("(a → b → STOP □ SKIP) ; STOP", "a", ("b → STOP ; STOP"));
     check_csp0_afters("(a → b → STOP □ SKIP) ; STOP", "b", ());
     check_csp0_afters("(a → b → STOP □ SKIP) ; STOP", "τ", ("STOP"));
     check_csp0_afters("(a → b → STOP □ SKIP) ; STOP", "✔", ());
-    /* Clean up. */
-    csp_free(csp);
 }
 
 TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP") {
-    struct csp  *csp;
-    /* Create the CSP environment. */
-    check_alloc(csp, csp_new());
-    /* a → STOP */
     check_csp0_initials("(a → b → STOP ⊓ SKIP) ; STOP", ("τ"));
     check_csp0_afters("(a → b → STOP ⊓ SKIP) ; STOP", "a", ());
     check_csp0_afters("(a → b → STOP ⊓ SKIP) ; STOP", "b", ());
     check_csp0_afters("(a → b → STOP ⊓ SKIP) ; STOP", "τ",
                       ("a → b → STOP ; STOP", "SKIP ; STOP"));
     check_csp0_afters("(a → b → STOP ⊓ SKIP) ; STOP", "✔", ());
-    /* Clean up. */
-    csp_free(csp);
 }


### PR DESCRIPTION
You can now define mutually recursive processes.  In CSP₀, this is done via the `let/within` statement.  (This has the same form as in CSPM, but without allowing you to parameterize the process definitions.)  Names are only in scope within the specific `let` statement where they're defined; we don't (currently) allow you to refer to processes in nested `let` statements.