### PR TITLE
Reformat everything via clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,61 @@
+Language: Cpp
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ColumnLimit: 80
+ContinuationIndentWidth: 8
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+#ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:    '^<.*\.h>'
+    Priority: 1
+  - Regex:    '^<.*'
+    Priority: 2
+  - Regex:    '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 0
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 8
+UseTab: Never

--- a/include/hst.h
+++ b/include/hst.h
@@ -22,15 +22,15 @@ extern "C" {
 
 /* Each process and event is identified by a number. */
 typedef uint64_t csp_id;
-#define CSP_ID_FMT  "0x%016" PRIx64
+#define CSP_ID_FMT "0x%016" PRIx64
 
-#define CSP_PROCESS_NONE  ((csp_id) 0)
+#define CSP_PROCESS_NONE ((csp_id) 0)
 
 struct csp {
-    csp_id  tau;
-    csp_id  tick;
-    csp_id  skip;
-    csp_id  stop;
+    csp_id tau;
+    csp_id tick;
+    csp_id skip;
+    csp_id stop;
 };
 
 struct csp *
@@ -63,22 +63,22 @@ csp_get_event_name(struct csp *csp, csp_id event);
  * to minimize malloc overhead for small sets.  We automatically calculate a
  * number that makes the size of the csp_id_set itself a nice multiple of
  * sizeof(void *).  On 64-bit platforms this should currently evaluate to 12. */
-#define CSP_ID_SET_INTERNAL_SIZE \
-    (((sizeof(void *) * 16) \
-      - sizeof(csp_id)    /* hash */ \
-      - sizeof(csp_id *)  /* ids */ \
-      - sizeof(size_t)    /* count */ \
-      - sizeof(size_t)    /* allocated_count */ \
-     ) / sizeof(void *))
+#define CSP_ID_SET_INTERNAL_SIZE                                   \
+    (((sizeof(void *) * 16) - sizeof(csp_id) /* hash */            \
+      - sizeof(csp_id *)                     /* ids */             \
+      - sizeof(size_t)                       /* count */           \
+      - sizeof(size_t)                       /* allocated_count */ \
+      ) /                                                          \
+     sizeof(void *))
 
 /* A set of IDs, stored as a sorted array.  This type is read-only; to construct
  * a set, use a csp_id_set_builder. */
 struct csp_id_set {
-    csp_id  hash;
-    csp_id  *ids;
-    size_t  count;
-    size_t  allocated_count;
-    csp_id  internal[CSP_ID_SET_INTERNAL_SIZE];
+    csp_id hash;
+    csp_id *ids;
+    size_t count;
+    size_t allocated_count;
+    csp_id internal[CSP_ID_SET_INTERNAL_SIZE];
 };
 
 void
@@ -132,8 +132,8 @@ csp_id_set_fill_double(struct csp_id_set *set, csp_id e1, csp_id e2);
 
 /* A writeable view of a set of IDs. */
 struct csp_id_set_builder {
-    csp_id  hash;
-    void  *working_set;
+    csp_id hash;
+    void *working_set;
 };
 
 /* Initialize and clear a set builder. */
@@ -188,24 +188,19 @@ csp_id_set_build_and_keep(struct csp_id_set *set,
  */
 
 struct csp_process_iface {
-    void
-    (*initials)(struct csp *csp, struct csp_id_set_builder *builder, void *ud);
+    void (*initials)(struct csp *csp, struct csp_id_set_builder *builder,
+                     void *ud);
 
-    void
-    (*afters)(struct csp *csp, csp_id initial,
-              struct csp_id_set_builder *builder, void *ud);
+    void (*afters)(struct csp *csp, csp_id initial,
+                   struct csp_id_set_builder *builder, void *ud);
 
-    csp_id
-    (*get_id)(struct csp *csp, const void *temp_ud);
+    csp_id (*get_id)(struct csp *csp, const void *temp_ud);
 
-    size_t
-    (*ud_size)(struct csp *csp, const void *temp_ud);
+    size_t (*ud_size)(struct csp *csp, const void *temp_ud);
 
-    void
-    (*init_ud)(struct csp *csp, void *ud, const void *temp_ud);
+    void (*init_ud)(struct csp *csp, void *ud, const void *temp_ud);
 
-    void
-    (*done_ud)(struct csp *csp, void *ud);
+    void (*done_ud)(struct csp *csp, void *ud);
 };
 
 /* Creates a new process.
@@ -281,7 +276,9 @@ csp_process_build_afters(struct csp *csp, csp_id process, csp_id initial,
  *     }
  */
 
-struct csp_id_scope { unsigned int unused; };
+struct csp_id_scope {
+    unsigned int unused;
+};
 
 csp_id
 csp_id_start(struct csp_id_scope *scope);
@@ -335,9 +332,9 @@ csp_sequential_composition(struct csp *csp, csp_id p, csp_id q);
  * in the definition of the process.  Presto, recursion! */
 
 struct csp_recursion_scope {
-    csp_id  scope;
-    size_t  unfilled_count;
-    void  *names;
+    csp_id scope;
+    size_t unfilled_count;
+    void *names;
 };
 
 /* Initialize a new recursion scope.  You are responsible for passing in a
@@ -392,7 +389,7 @@ csp_load_csp0_string(struct csp *csp, const char *str, csp_id *dest);
  * Normalized LTS
  */
 
-#define CSP_NODE_NONE  ((csp_id) 0)
+#define CSP_NODE_NONE ((csp_id) 0)
 
 struct csp_normalized_lts;
 

--- a/src/hst/hst.c
+++ b/src/hst/hst.c
@@ -6,7 +6,7 @@
  */
 
 int
-main(int argc, char** argv)
+main(int argc, char **argv)
 {
     return 0;
 }

--- a/src/libhst/environment.c
+++ b/src/libhst/environment.c
@@ -19,29 +19,29 @@
 #include "hst.h"
 
 static uint64_t
-hash_sized_name(const char* name, size_t name_length)
+hash_sized_name(const char *name, size_t name_length)
 {
     return hash64_any(name, name_length, 0);
 }
 
 static uint64_t
-hash_name(const char* name)
+hash_name(const char *name)
 {
     return hash_sized_name(name, strlen(name));
 }
 
 struct csp_process {
-    const struct csp_process_iface  iface;
+    const struct csp_process_iface iface;
 };
 
-#define csp_process_ud(proc)  ((void *) (((struct csp_process *) (proc)) + 1))
+#define csp_process_ud(proc) ((void *) (((struct csp_process *) (proc)) + 1))
 
 static struct csp_process *
 csp_process_new(struct csp *csp, const void *temp_ud,
                 const struct csp_process_iface *iface)
 {
-    size_t  ud_size = iface->ud_size(csp, temp_ud);
-    struct csp_process  *process = malloc(sizeof(struct csp_process) + ud_size);
+    size_t ud_size = iface->ud_size(csp, temp_ud);
+    struct csp_process *process = malloc(sizeof(struct csp_process) + ud_size);
     assert(process != NULL);
     iface->init_ud(csp, csp_process_ud(process), temp_ud);
     *((struct csp_process_iface *) &process->iface) = *iface;
@@ -56,12 +56,12 @@ csp_process_free(struct csp *csp, struct csp_process *process)
 }
 
 struct csp_priv {
-    struct csp  public;
-    csp_id  next_recursion_scope_id;
-    void  *events;
-    void  *processes;
-    struct csp_process  *stop;
-    struct csp_process  *skip;
+    struct csp public;
+    csp_id next_recursion_scope_id;
+    void *events;
+    void *processes;
+    struct csp_process *stop;
+    struct csp_process *skip;
 };
 
 static struct csp_process *
@@ -104,19 +104,14 @@ csp_stop_done(struct csp *pcsp, void *ud)
 }
 
 const struct csp_process_iface csp_stop_iface = {
-    &csp_stop_initials,
-    &csp_stop_afters,
-    &csp_stop_get_id,
-    &csp_stop_ud_size,
-    &csp_stop_init,
-    &csp_stop_done
-};
+        &csp_stop_initials, &csp_stop_afters, &csp_stop_get_id,
+        &csp_stop_ud_size,  &csp_stop_init,   &csp_stop_done};
 
 static void
 csp_skip_initials(struct csp *pcsp, struct csp_id_set_builder *builder,
                   void *ud)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
     csp_id_set_builder_add(builder, csp->public.tick);
 }
 
@@ -124,7 +119,7 @@ static void
 csp_skip_afters(struct csp *pcsp, csp_id initial,
                 struct csp_id_set_builder *builder, void *ud)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
     if (initial == csp->public.tick) {
         csp_id_set_builder_add(builder, csp->public.stop);
     }
@@ -155,20 +150,15 @@ csp_skip_done(struct csp *pcsp, void *ud)
 }
 
 const struct csp_process_iface csp_skip_iface = {
-    &csp_skip_initials,
-    &csp_skip_afters,
-    &csp_skip_get_id,
-    &csp_skip_ud_size,
-    &csp_skip_init,
-    &csp_skip_done
-};
+        &csp_skip_initials, &csp_skip_afters, &csp_skip_get_id,
+        &csp_skip_ud_size,  &csp_skip_init,   &csp_skip_done};
 
 struct csp *
 csp_new(void)
 {
-    static const char* const TAU = "τ";
-    static const char* const TICK = "✔";
-    struct csp_priv  *csp = malloc(sizeof(struct csp_priv));
+    static const char *const TAU = "τ";
+    static const char *const TICK = "✔";
+    struct csp_priv *csp = malloc(sizeof(struct csp_priv));
     if (unlikely(csp == NULL)) {
         return NULL;
     }
@@ -177,11 +167,11 @@ csp_new(void)
     csp->next_recursion_scope_id = 0;
     csp->public.tau = csp_get_event_id(&csp->public, TAU);
     csp->public.tick = csp_get_event_id(&csp->public, TICK);
-    csp->public.stop = csp_process_init(
-            &csp->public, NULL, NULL, &csp_stop_iface);
+    csp->public.stop =
+            csp_process_init(&csp->public, NULL, NULL, &csp_stop_iface);
     csp->stop = csp_process_get(csp, csp->public.stop);
-    csp->public.skip = csp_process_init(
-            &csp->public, NULL, NULL, &csp_skip_iface);
+    csp->public.skip =
+            csp_process_init(&csp->public, NULL, NULL, &csp_skip_iface);
     csp->skip = csp_process_get(csp, csp->public.skip);
     return &csp->public;
 }
@@ -189,15 +179,15 @@ csp_new(void)
 void
 csp_free(struct csp *pcsp)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    UNNEEDED Word_t  dummy;
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    UNNEEDED Word_t dummy;
 
     {
-        Word_t  *vname;
-        csp_id  event = 0;
+        Word_t *vname;
+        csp_id event = 0;
         JLF(vname, csp->events, event);
         while (vname != NULL) {
-            char  *name = (void *) *vname;
+            char *name = (void *) *vname;
             free(name);
             JLN(vname, csp->events, event);
         }
@@ -205,11 +195,11 @@ csp_free(struct csp *pcsp)
     }
 
     {
-        Word_t  *vprocess;
-        csp_id  process_id = 0;
+        Word_t *vprocess;
+        csp_id process_id = 0;
         JLF(vprocess, csp->processes, process_id);
         while (vprocess != NULL) {
-            struct csp_process  *process = (void *) *vprocess;
+            struct csp_process *process = (void *) *vprocess;
             csp_process_free(&csp->public, process);
             JLN(vprocess, csp->processes, process_id);
         }
@@ -222,12 +212,12 @@ csp_free(struct csp *pcsp)
 csp_id
 csp_get_event_id(struct csp *pcsp, const char *name)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    csp_id  event = hash_name(name);
-    Word_t  *vname;
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    csp_id event = hash_name(name);
+    Word_t *vname;
     JLI(vname, csp->events, event);
     if (*vname == 0) {
-        const char  *name_copy = strdup(name);
+        const char *name_copy = strdup(name);
         *vname = (Word_t) name_copy;
     }
     return event;
@@ -236,12 +226,12 @@ csp_get_event_id(struct csp *pcsp, const char *name)
 csp_id
 csp_get_sized_event_id(struct csp *pcsp, const char *name, size_t name_length)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    csp_id  event = hash_sized_name(name, name_length);
-    Word_t  *vname;
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    csp_id event = hash_sized_name(name, name_length);
+    Word_t *vname;
     JLI(vname, csp->events, event);
     if (*vname == 0) {
-        char  *name_copy = malloc(name_length + 1);
+        char *name_copy = malloc(name_length + 1);
         memcpy(name_copy, name, name_length);
         name_copy[name_length] = '\0';
         *vname = (Word_t) name_copy;
@@ -252,8 +242,8 @@ csp_get_sized_event_id(struct csp *pcsp, const char *name, size_t name_length)
 const char *
 csp_get_event_name(struct csp *pcsp, csp_id event)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    Word_t  *vname;
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    Word_t *vname;
     JLG(vname, csp->events, event);
     if (vname == NULL) {
         return NULL;
@@ -266,10 +256,10 @@ csp_id
 csp_process_init(struct csp *pcsp, const void *temp_ud, void **ud,
                  const struct csp_process_iface *iface)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    struct csp_process  *process;
-    csp_id  process_id = iface->get_id(&csp->public, temp_ud);
-    Word_t  *vprocess;
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_process *process;
+    csp_id process_id = iface->get_id(&csp->public, temp_ud);
+    Word_t *vprocess;
     JLI(vprocess, csp->processes, process_id);
     if (*vprocess == 0) {
         process = csp_process_new(&csp->public, temp_ud, iface);
@@ -286,7 +276,7 @@ csp_process_init(struct csp *pcsp, const void *temp_ud, void **ud,
 static struct csp_process *
 csp_process_get(struct csp_priv *csp, csp_id process_id)
 {
-    Word_t  *vprocess;
+    Word_t *vprocess;
     JLG(vprocess, csp->processes, process_id);
     /* It's an error to do something with a process that you haven't created
      * yet. */
@@ -298,8 +288,8 @@ void
 csp_process_build_initials(struct csp *pcsp, csp_id process_id,
                            struct csp_id_set_builder *builder)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    struct csp_process  *process = csp_process_get(csp, process_id);
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_process *process = csp_process_get(csp, process_id);
     process->iface.initials(&csp->public, builder, csp_process_ud(process));
 }
 
@@ -307,10 +297,10 @@ void
 csp_process_build_afters(struct csp *pcsp, csp_id process_id, csp_id initial,
                          struct csp_id_set_builder *builder)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
-    struct csp_process  *process = csp_process_get(csp, process_id);
-    process->iface.afters(
-            &csp->public, initial, builder, csp_process_ud(process));
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_process *process = csp_process_get(csp, process_id);
+    process->iface.afters(&csp->public, initial, builder,
+                          csp_process_ud(process));
 }
 
 csp_id

--- a/src/libhst/id-set.c
+++ b/src/libhst/id-set.c
@@ -23,7 +23,7 @@
  * event IDs.  You then simply XOR together the hashes of each element (possibly
  * along with some initial base value) to get the hash of the set. */
 
-#define CSP_ID_SET_INITIAL_HASH  UINT64_C(0x1866bb10b2b2fad7) /* random */
+#define CSP_ID_SET_INITIAL_HASH UINT64_C(0x1866bb10b2b2fad7) /* random */
 
 void
 csp_id_set_init(struct csp_id_set *set)
@@ -64,14 +64,14 @@ csp_id_set_builder_init(struct csp_id_set_builder *builder)
 void
 csp_id_set_builder_done(struct csp_id_set_builder *builder)
 {
-    UNNEEDED Word_t  dummy;
+    UNNEEDED Word_t dummy;
     J1FA(dummy, builder->working_set);
 }
 
 static bool
 csp_id_set_builder_add_one(struct csp_id_set_builder *builder, csp_id id)
 {
-    int  rc;
+    int rc;
     J1S(rc, builder->working_set, id);
     if (rc) {
         /* Only update the set's hash if we actually added a new element. */
@@ -83,7 +83,7 @@ csp_id_set_builder_add_one(struct csp_id_set_builder *builder, csp_id id)
 static bool
 csp_id_set_builder_remove_one(struct csp_id_set_builder *builder, csp_id id)
 {
-    int  rc;
+    int rc;
     J1U(rc, builder->working_set, id);
     if (rc) {
         /* Only update the set's hash if we actually removed an element. */
@@ -102,7 +102,7 @@ void
 csp_id_set_builder_add_many(struct csp_id_set_builder *builder, size_t count,
                             csp_id *ids)
 {
-    size_t  i;
+    size_t i;
     for (i = 0; i < count; i++) {
         csp_id_set_builder_add_one(builder, ids[i]);
     }
@@ -118,7 +118,7 @@ void
 csp_id_set_builder_remove_many(struct csp_id_set_builder *builder, size_t count,
                                csp_id *ids)
 {
-    size_t  i;
+    size_t i;
     for (i = 0; i < count; i++) {
         csp_id_set_builder_remove_one(builder, ids[i]);
     }
@@ -128,13 +128,13 @@ void
 csp_id_set_builder_merge(struct csp_id_set_builder *builder,
                          const struct csp_id_set *set)
 {
-    size_t  i;
+    size_t i;
     for (i = 0; i < set->count; i++) {
         csp_id_set_builder_add_one(builder, set->ids[i]);
     }
 }
 
-#define CSP_ID_SET_FIRST_ALLOCATION_COUNT  32
+#define CSP_ID_SET_FIRST_ALLOCATION_COUNT 32
 
 /* Ensure that `set` is large enough to hold `set->count` elements. */
 static void
@@ -142,7 +142,7 @@ csp_id_set_ensure_size(struct csp_id_set *set)
 {
     if (unlikely(set->count > set->allocated_count)) {
         if (set->ids == set->internal) {
-            size_t  new_count = CSP_ID_SET_FIRST_ALLOCATION_COUNT;
+            size_t new_count = CSP_ID_SET_FIRST_ALLOCATION_COUNT;
             while (set->count > new_count) {
                 new_count *= 2;
             }
@@ -152,8 +152,8 @@ csp_id_set_ensure_size(struct csp_id_set *set)
         } else {
             /* Whenever we reallocate, at least double the size of the existing
              * array. */
-            csp_id  *new_ids;
-            size_t  new_count = set->allocated_count;
+            csp_id *new_ids;
+            size_t new_count = set->allocated_count;
             do {
                 new_count *= 2;
             } while (set->count > new_count);
@@ -169,10 +169,10 @@ void
 csp_id_set_build_and_keep(struct csp_id_set *set,
                           struct csp_id_set_builder *builder)
 {
-    int  found;
-    Word_t  count;
-    size_t  i;
-    csp_id  id;
+    int found;
+    Word_t count;
+    size_t i;
+    csp_id id;
 
     /* First make sure that the `ids` array is large enough to hold all of the
      * ids that have been added to the set. */
@@ -195,7 +195,7 @@ csp_id_set_build_and_keep(struct csp_id_set *set,
 void
 csp_id_set_build(struct csp_id_set *set, struct csp_id_set_builder *builder)
 {
-    UNNEEDED Word_t  dummy;
+    UNNEEDED Word_t dummy;
     csp_id_set_build_and_keep(set, builder);
     J1FA(dummy, builder->working_set);
     builder->hash = CSP_ID_SET_INITIAL_HASH;

--- a/src/libhst/normalized-lts.c
+++ b/src/libhst/normalized-lts.c
@@ -15,15 +15,15 @@
 #include "hst.h"
 
 struct csp_normalized_lts_node {
-    struct csp_id_set  processes;
-    void  *edges;
+    struct csp_id_set processes;
+    void *edges;
 };
 
 static struct csp_normalized_lts_node *
 csp_normalized_lts_node_new(const struct csp_id_set *processes)
 {
-    struct csp_normalized_lts_node  *node =
-        malloc(sizeof(struct csp_normalized_lts_node));
+    struct csp_normalized_lts_node *node =
+            malloc(sizeof(struct csp_normalized_lts_node));
     assert(node != NULL);
     csp_id_set_init(&node->processes);
     csp_id_set_clone(&node->processes, processes);
@@ -34,7 +34,7 @@ csp_normalized_lts_node_new(const struct csp_id_set *processes)
 static void
 csp_normalized_lts_node_free(struct csp_normalized_lts_node *node)
 {
-    UNNEEDED Word_t  dummy;
+    UNNEEDED Word_t dummy;
     csp_id_set_done(&node->processes);
     JLFA(dummy, node->edges);
     free(node);
@@ -44,7 +44,7 @@ static void
 csp_normalized_lts_node_add_edge(struct csp_normalized_lts_node *node,
                                  csp_id event, csp_id to)
 {
-    Word_t  *vto;
+    Word_t *vto;
     JLI(vto, node->edges, event);
     assert(*vto == 0);
     *vto = to;
@@ -54,7 +54,7 @@ static csp_id
 csp_normalized_lts_node_get_edge(struct csp_normalized_lts_node *node,
                                  csp_id event)
 {
-    Word_t  *vto;
+    Word_t *vto;
     JLG(vto, node->edges, event);
     if (vto == NULL) {
         return CSP_NODE_NONE;
@@ -64,13 +64,13 @@ csp_normalized_lts_node_get_edge(struct csp_normalized_lts_node *node,
 }
 
 struct csp_normalized_lts {
-    void  *nodes;
+    void *nodes;
 };
 
 struct csp_normalized_lts *
 csp_normalized_lts_new(struct csp *csp)
 {
-    struct csp_normalized_lts  *lts = malloc(sizeof(struct csp_normalized_lts));
+    struct csp_normalized_lts *lts = malloc(sizeof(struct csp_normalized_lts));
     assert(lts != NULL);
     lts->nodes = NULL;
     return lts;
@@ -80,12 +80,12 @@ void
 csp_normalized_lts_free(struct csp_normalized_lts *lts)
 {
     {
-        UNNEEDED Word_t  dummy;
-        Word_t  *vnode;
-        csp_id  id = 0;
+        UNNEEDED Word_t dummy;
+        Word_t *vnode;
+        csp_id id = 0;
         JLF(vnode, lts->nodes, id);
         while (vnode != NULL) {
-            struct csp_normalized_lts_node  *node = (void *) *vnode;
+            struct csp_normalized_lts_node *node = (void *) *vnode;
             csp_normalized_lts_node_free(node);
             JLN(vnode, lts->nodes, id);
         }
@@ -98,13 +98,13 @@ bool
 csp_normalized_lts_add_node(struct csp_normalized_lts *lts,
                             const struct csp_id_set *processes, csp_id *dest)
 {
-    csp_id  id = processes->hash;
-    Word_t  *vnode;
+    csp_id id = processes->hash;
+    Word_t *vnode;
     *dest = id;
     JLI(vnode, lts->nodes, id);
     if (*vnode == 0) {
-        struct csp_normalized_lts_node  *node =
-            csp_normalized_lts_node_new(processes);
+        struct csp_normalized_lts_node *node =
+                csp_normalized_lts_node_new(processes);
         *vnode = (Word_t) node;
         return true;
     } else {
@@ -115,7 +115,7 @@ csp_normalized_lts_add_node(struct csp_normalized_lts *lts,
 static struct csp_normalized_lts_node *
 csp_normalized_lts_get_node(struct csp_normalized_lts *lts, csp_id id)
 {
-    Word_t  *vnode;
+    Word_t *vnode;
     JLG(vnode, lts->nodes, id);
     assert(vnode != NULL);
     return (void *) *vnode;
@@ -125,7 +125,7 @@ void
 csp_normalized_lts_add_edge(struct csp_normalized_lts *lts, csp_id from,
                             csp_id event, csp_id to)
 {
-    struct csp_normalized_lts_node  *from_node;
+    struct csp_normalized_lts_node *from_node;
     from_node = csp_normalized_lts_get_node(lts, from);
     assert(from_node != NULL);
     assert(csp_normalized_lts_get_node(lts, to) != NULL);
@@ -133,11 +133,9 @@ csp_normalized_lts_add_edge(struct csp_normalized_lts *lts, csp_id from,
 }
 
 const struct csp_id_set *
-csp_normalized_lts_get_node_processes(struct csp_normalized_lts *lts,
-                                      csp_id id)
+csp_normalized_lts_get_node_processes(struct csp_normalized_lts *lts, csp_id id)
 {
-    struct csp_normalized_lts_node  *node =
-        csp_normalized_lts_get_node(lts, id);
+    struct csp_normalized_lts_node *node = csp_normalized_lts_get_node(lts, id);
     return &node->processes;
 }
 
@@ -145,7 +143,7 @@ csp_id
 csp_normalized_lts_get_edge(struct csp_normalized_lts *lts, csp_id from,
                             csp_id event)
 {
-    struct csp_normalized_lts_node  *from_node;
+    struct csp_normalized_lts_node *from_node;
     from_node = csp_normalized_lts_get_node(lts, from);
     assert(from_node != NULL);
     return csp_normalized_lts_node_get_edge(from_node, event);

--- a/src/libhst/operators/external-choice.c
+++ b/src/libhst/operators/external-choice.c
@@ -12,7 +12,7 @@
 #include "hst.h"
 
 struct csp_external_choice {
-    struct csp_id_set  ps;
+    struct csp_id_set ps;
 };
 
 /* Operational semantics for □ Ps
@@ -38,8 +38,8 @@ csp_external_choice_initials(struct csp *csp,
      *
      *                = ⋃ { initials(P) | P ∈ Ps }
      */
-    struct csp_external_choice  *choice = vchoice;
-    size_t  i;
+    struct csp_external_choice *choice = vchoice;
+    size_t i;
     for (i = 0; i < choice->ps.count; i++) {
         csp_process_build_initials(csp, choice->ps.ids[i], builder);
     }
@@ -53,16 +53,16 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
      *                                                                  [rule 1]
      * afters(□ Ps, a ≠ τ) = ⋃ { P' | P ∈ Ps, P' ∈ afters(P, a) }       [rule 2]
      */
-    struct csp_external_choice  *choice = vchoice;
+    struct csp_external_choice *choice = vchoice;
     if (initial == csp->tau) {
-        size_t  i;
+        size_t i;
         /* We'll need to grab afters(P, τ) for each P ∈ Ps. */
-        struct csp_id_set  p_afters;
-        struct csp_id_set_builder  p_afters_builder;
+        struct csp_id_set p_afters;
+        struct csp_id_set_builder p_afters_builder;
         /* We're going to build up a lot of new Ps' sets that all have the same
          * basic structure: Ps' = Ps ∖ {P} ∪ {P'} */
-        struct csp_id_set  ps_prime;
-        struct csp_id_set_builder  ps_prime_builder;
+        struct csp_id_set ps_prime;
+        struct csp_id_set_builder ps_prime_builder;
         csp_id_set_init(&p_afters);
         csp_id_set_builder_init(&p_afters_builder);
         csp_id_set_init(&ps_prime);
@@ -72,8 +72,8 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
         csp_id_set_builder_merge(&ps_prime_builder, &choice->ps);
         /* For all P ∈ Ps */
         for (i = 0; i < choice->ps.count; i++) {
-            size_t  j;
-            csp_id  p = choice->ps.ids[i];
+            size_t j;
+            csp_id p = choice->ps.ids[i];
             /* Set Ps' to Ps ∖ {P} */
             csp_id_set_builder_remove(&ps_prime_builder, p);
             /* Grab afters(P, τ) */
@@ -81,7 +81,7 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
             csp_id_set_build(&p_afters, &p_afters_builder);
             /* For all P' ∈ afters(P, τ) */
             for (j = 0; j < p_afters.count; j++) {
-                csp_id  p_prime = p_afters.ids[j];
+                csp_id p_prime = p_afters.ids[j];
                 /* ps_prime_builder currently contains Ps.  Add P' and
                  * remove P to produce (Ps ∖ {P} ∪ {P'}) */
                 csp_id_set_builder_add(&ps_prime_builder, p_prime);
@@ -90,8 +90,8 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
                  * build_and_keep variant so that we don't throw away all our
                  * work. */
                 csp_id_set_build_and_keep(&ps_prime, &ps_prime_builder);
-                csp_id_set_builder_add(builder,
-                        csp_replicated_external_choice(csp, &ps_prime));
+                csp_id_set_builder_add(builder, csp_replicated_external_choice(
+                                                        csp, &ps_prime));
                 /* Reset Ps' back to Ps ∖ {P}. */
                 csp_id_set_builder_remove(&ps_prime_builder, p_prime);
             }
@@ -103,9 +103,9 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
         csp_id_set_done(&ps_prime);
         csp_id_set_builder_done(&ps_prime_builder);
     } else {
-        size_t  i;
+        size_t i;
         for (i = 0; i < choice->ps.count; i++) {
-            csp_id  p = choice->ps.ids[i];
+            csp_id p = choice->ps.ids[i];
             csp_process_build_afters(csp, p, initial, builder);
         }
     }
@@ -114,9 +114,9 @@ csp_external_choice_afters(struct csp *csp, csp_id initial,
 static csp_id
 csp_external_choice_get_id(struct csp *csp, const void *vps)
 {
-    const struct csp_id_set  *ps = vps;
-    static struct csp_id_scope  external_choice;
-    csp_id  id = csp_id_start(&external_choice);
+    const struct csp_id_set *ps = vps;
+    static struct csp_id_scope external_choice;
+    csp_id id = csp_id_start(&external_choice);
     id = csp_id_add_id_set(id, ps);
     return id;
 }
@@ -130,8 +130,8 @@ csp_external_choice_ud_size(struct csp *csp, const void *vps)
 static void
 csp_external_choice_init(struct csp *csp, void *vchoice, const void *vps)
 {
-    struct csp_external_choice  *choice = vchoice;
-    const struct csp_id_set  *ps = vps;
+    struct csp_external_choice *choice = vchoice;
+    const struct csp_id_set *ps = vps;
     csp_id_set_init(&choice->ps);
     csp_id_set_clone(&choice->ps, ps);
 }
@@ -139,24 +139,20 @@ csp_external_choice_init(struct csp *csp, void *vchoice, const void *vps)
 static void
 csp_external_choice_done(struct csp *csp, void *vchoice)
 {
-    struct csp_external_choice  *choice = vchoice;
+    struct csp_external_choice *choice = vchoice;
     csp_id_set_done(&choice->ps);
 }
 
-static const struct csp_process_iface  csp_external_choice_iface = {
-    &csp_external_choice_initials,
-    &csp_external_choice_afters,
-    &csp_external_choice_get_id,
-    &csp_external_choice_ud_size,
-    &csp_external_choice_init,
-    &csp_external_choice_done
-};
+static const struct csp_process_iface csp_external_choice_iface = {
+        &csp_external_choice_initials, &csp_external_choice_afters,
+        &csp_external_choice_get_id,   &csp_external_choice_ud_size,
+        &csp_external_choice_init,     &csp_external_choice_done};
 
 csp_id
 csp_external_choice(struct csp *csp, csp_id a, csp_id b)
 {
-    csp_id  id;
-    struct csp_id_set  ps;
+    csp_id id;
+    struct csp_id_set ps;
     csp_id_set_init(&ps);
     csp_id_set_fill_double(&ps, a, b);
     id = csp_process_init(csp, &ps, NULL, &csp_external_choice_iface);

--- a/src/libhst/operators/internal-choice.c
+++ b/src/libhst/operators/internal-choice.c
@@ -12,7 +12,7 @@
 #include "hst.h"
 
 struct csp_internal_choice {
-    struct csp_id_set  ps;
+    struct csp_id_set ps;
 };
 
 /* Operational semantics for ⊓ Ps
@@ -34,7 +34,7 @@ csp_internal_choice_afters(struct csp *csp, csp_id initial,
                            struct csp_id_set_builder *builder, void *vchoice)
 {
     /* afters(⊓ Ps, τ) = Ps */
-    struct csp_internal_choice  *choice = vchoice;
+    struct csp_internal_choice *choice = vchoice;
     if (initial == csp->tau) {
         csp_id_set_builder_merge(builder, &choice->ps);
     }
@@ -43,9 +43,9 @@ csp_internal_choice_afters(struct csp *csp, csp_id initial,
 static csp_id
 csp_internal_choice_get_id(struct csp *csp, const void *vps)
 {
-    const struct csp_id_set  *ps = vps;
-    static struct csp_id_scope  internal_choice;
-    csp_id  id = csp_id_start(&internal_choice);
+    const struct csp_id_set *ps = vps;
+    static struct csp_id_scope internal_choice;
+    csp_id id = csp_id_start(&internal_choice);
     id = csp_id_add_id_set(id, ps);
     return id;
 }
@@ -59,8 +59,8 @@ csp_internal_choice_ud_size(struct csp *csp, const void *temp_ud)
 static void
 csp_internal_choice_init(struct csp *csp, void *vchoice, const void *vps)
 {
-    struct csp_internal_choice  *choice = vchoice;
-    const struct csp_id_set  *ps = vps;
+    struct csp_internal_choice *choice = vchoice;
+    const struct csp_id_set *ps = vps;
     csp_id_set_init(&choice->ps);
     csp_id_set_clone(&choice->ps, ps);
 }
@@ -68,24 +68,20 @@ csp_internal_choice_init(struct csp *csp, void *vchoice, const void *vps)
 static void
 csp_internal_choice_done(struct csp *csp, void *vchoice)
 {
-    struct csp_internal_choice  *choice = vchoice;
+    struct csp_internal_choice *choice = vchoice;
     csp_id_set_done(&choice->ps);
 }
 
-static const struct csp_process_iface  csp_internal_choice_iface = {
-    &csp_internal_choice_initials,
-    &csp_internal_choice_afters,
-    &csp_internal_choice_get_id,
-    &csp_internal_choice_ud_size,
-    &csp_internal_choice_init,
-    &csp_internal_choice_done
-};
+static const struct csp_process_iface csp_internal_choice_iface = {
+        &csp_internal_choice_initials, &csp_internal_choice_afters,
+        &csp_internal_choice_get_id,   &csp_internal_choice_ud_size,
+        &csp_internal_choice_init,     &csp_internal_choice_done};
 
 csp_id
 csp_internal_choice(struct csp *csp, csp_id a, csp_id b)
 {
-    csp_id  id;
-    struct csp_id_set  ps;
+    csp_id id;
+    struct csp_id_set ps;
     csp_id_set_init(&ps);
     csp_id_set_fill_double(&ps, a, b);
     id = csp_process_init(csp, &ps, NULL, &csp_internal_choice_iface);

--- a/src/libhst/operators/prefix.c
+++ b/src/libhst/operators/prefix.c
@@ -11,8 +11,8 @@
 #include "hst.h"
 
 struct csp_prefix {
-    csp_id  a;
-    csp_id  p;
+    csp_id a;
+    csp_id p;
 };
 
 /* Operational semantics for a → P
@@ -26,7 +26,7 @@ csp_prefix_initials(struct csp *csp, struct csp_id_set_builder *builder,
                     void *vprefix)
 {
     /* initials(a → P) = {a} */
-    struct csp_prefix  *prefix = vprefix;
+    struct csp_prefix *prefix = vprefix;
     csp_id_set_builder_add(builder, prefix->a);
 }
 
@@ -35,7 +35,7 @@ csp_prefix_afters(struct csp *csp, csp_id initial,
                   struct csp_id_set_builder *builder, void *vprefix)
 {
     /* afters(a → P, a) = P */
-    struct csp_prefix  *prefix = vprefix;
+    struct csp_prefix *prefix = vprefix;
     if (initial == prefix->a) {
         csp_id_set_builder_add(builder, prefix->p);
     }
@@ -44,9 +44,9 @@ csp_prefix_afters(struct csp *csp, csp_id initial,
 static csp_id
 csp_prefix_get_id(struct csp *csp, const void *vinput)
 {
-    const struct csp_prefix  *input = vinput;
-    static struct csp_id_scope  prefix;
-    csp_id  id = csp_id_start(&prefix);
+    const struct csp_prefix *input = vinput;
+    static struct csp_id_scope prefix;
+    csp_id id = csp_id_start(&prefix);
     id = csp_id_add_id(id, input->a);
     id = csp_id_add_id(id, input->p);
     return id;
@@ -61,8 +61,8 @@ csp_prefix_ud_size(struct csp *csp, const void *vinput)
 static void
 csp_prefix_init(struct csp *csp, void *vprefix, const void *vinput)
 {
-    struct csp_prefix  *prefix = vprefix;
-    const struct csp_prefix  *input = vinput;
+    struct csp_prefix *prefix = vprefix;
+    const struct csp_prefix *input = vinput;
     prefix->a = input->a;
     prefix->p = input->p;
 }
@@ -73,18 +73,13 @@ csp_prefix_done(struct csp *csp, void *vprefix)
     /* nothing to do */
 }
 
-static const struct csp_process_iface  csp_prefix_iface = {
-    &csp_prefix_initials,
-    &csp_prefix_afters,
-    &csp_prefix_get_id,
-    &csp_prefix_ud_size,
-    &csp_prefix_init,
-    &csp_prefix_done
-};
+static const struct csp_process_iface csp_prefix_iface = {
+        &csp_prefix_initials, &csp_prefix_afters, &csp_prefix_get_id,
+        &csp_prefix_ud_size,  &csp_prefix_init,   &csp_prefix_done};
 
 csp_id
 csp_prefix(struct csp *csp, csp_id a, csp_id p)
 {
-    struct csp_prefix  input = { a, p };
+    struct csp_prefix input = {a, p};
     return csp_process_init(csp, &input, NULL, &csp_prefix_iface);
 }

--- a/src/libhst/operators/recursion.c
+++ b/src/libhst/operators/recursion.c
@@ -20,14 +20,14 @@
 #include "hst.h"
 
 struct csp_priv {
-    struct csp  public;
-    csp_id  next_recursion_scope_id;
+    struct csp public;
+    csp_id next_recursion_scope_id;
 };
 
 void
 csp_recursion_scope_init(struct csp *pcsp, struct csp_recursion_scope *scope)
 {
-    struct csp_priv  *csp = container_of(pcsp, struct csp_priv, public);
+    struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
     scope->scope = csp->next_recursion_scope_id++;
     scope->unfilled_count = 0;
     scope->names = NULL;
@@ -36,19 +36,19 @@ csp_recursion_scope_init(struct csp *pcsp, struct csp_recursion_scope *scope)
 void
 csp_recursion_scope_done(struct csp_recursion_scope *scope)
 {
-    UNNEEDED Word_t  dummy;
+    UNNEEDED Word_t dummy;
     JLFA(dummy, scope->names);
 }
 
 struct csp_recursion {
-    csp_id  process;
+    csp_id process;
 };
 
 static void
 csp_recursion_initials(struct csp *csp, struct csp_id_set_builder *builder,
                        void *vrecursion)
 {
-    struct csp_recursion  *recursion = vrecursion;
+    struct csp_recursion *recursion = vrecursion;
     assert(recursion->process != CSP_PROCESS_NONE);
     csp_process_build_initials(csp, recursion->process, builder);
 }
@@ -57,7 +57,7 @@ static void
 csp_recursion_afters(struct csp *csp, csp_id initial,
                      struct csp_id_set_builder *builder, void *vrecursion)
 {
-    struct csp_recursion  *recursion = vrecursion;
+    struct csp_recursion *recursion = vrecursion;
     assert(recursion->process != CSP_PROCESS_NONE);
     csp_process_build_afters(csp, recursion->process, initial, builder);
 }
@@ -65,7 +65,7 @@ csp_recursion_afters(struct csp *csp, csp_id initial,
 static csp_id
 csp_recursion_get_id(struct csp *csp, const void *vinput)
 {
-    const csp_id  *input = vinput;
+    const csp_id *input = vinput;
     return *input;
 }
 
@@ -78,7 +78,7 @@ csp_recursion_ud_size(struct csp *csp, const void *vinput)
 static void
 csp_recursion_init(struct csp *csp, void *vrecursion, const void *vinput)
 {
-    struct csp_recursion  *recursion = vrecursion;
+    struct csp_recursion *recursion = vrecursion;
     recursion->process = CSP_PROCESS_NONE;
 }
 
@@ -88,14 +88,9 @@ csp_recursion_done(struct csp *csp, void *vrecursion)
     /* nothing to do */
 }
 
-static const struct csp_process_iface  csp_recursion_iface = {
-    &csp_recursion_initials,
-    &csp_recursion_afters,
-    &csp_recursion_get_id,
-    &csp_recursion_ud_size,
-    &csp_recursion_init,
-    &csp_recursion_done
-};
+static const struct csp_process_iface csp_recursion_iface = {
+        &csp_recursion_initials, &csp_recursion_afters, &csp_recursion_get_id,
+        &csp_recursion_ud_size,  &csp_recursion_init,   &csp_recursion_done};
 
 static void
 csp_recursion(struct csp *csp, csp_id id, struct csp_recursion **recursion)
@@ -109,8 +104,8 @@ csp_recursion(struct csp *csp, csp_id id, struct csp_recursion **recursion)
 csp_id
 csp__recursion_create_id(csp_id scope, const char *name, size_t name_length)
 {
-    static struct csp_id_scope  recursion;
-    csp_id  id = csp_id_start(&recursion);
+    static struct csp_id_scope recursion;
+    csp_id id = csp_id_start(&recursion);
     id = csp_id_add_id(id, scope);
     id = csp_id_add_name_sized(id, name, name_length);
     return id;
@@ -128,11 +123,11 @@ csp_recursion_scope_get_sized(struct csp *csp,
                               struct csp_recursion_scope *scope,
                               const char *name, size_t name_length)
 {
-    Word_t  *vrecursion;
-    csp_id  id = csp__recursion_create_id(scope->scope, name, name_length);
+    Word_t *vrecursion;
+    csp_id id = csp__recursion_create_id(scope->scope, name, name_length);
     JLI(vrecursion, scope->names, id);
     if (*vrecursion == 0) {
-        struct csp_recursion  *recursion = NULL;
+        struct csp_recursion *recursion = NULL;
         csp_recursion(csp, id, &recursion);
         *vrecursion = (Word_t) recursion;
         scope->unfilled_count++;
@@ -152,13 +147,13 @@ csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
                                const char *name, size_t name_length,
                                csp_id process)
 {
-    Word_t  *vrecursion;
-    csp_id  id = csp__recursion_create_id(scope->scope, name, name_length);
+    Word_t *vrecursion;
+    csp_id id = csp__recursion_create_id(scope->scope, name, name_length);
     JLG(vrecursion, scope->names, id);
     if (unlikely(vrecursion == NULL)) {
         return false;
     } else {
-        struct csp_recursion  *recursion = (void *) *vrecursion;
+        struct csp_recursion *recursion = (void *) *vrecursion;
         if (likely(recursion->process == CSP_PROCESS_NONE)) {
             scope->unfilled_count--;
             recursion->process = process;

--- a/src/libhst/operators/sequential-composition.c
+++ b/src/libhst/operators/sequential-composition.c
@@ -11,8 +11,8 @@
 #include "hst.h"
 
 struct csp_sequential_composition {
-    csp_id  p;
-    csp_id  q;
+    csp_id p;
+    csp_id q;
 };
 
 /* Operational semantics for P ; Q
@@ -31,7 +31,7 @@ csp_sequential_composition_initials(struct csp *csp,
                                     struct csp_id_set_builder *builder,
                                     void *vseq)
 {
-    struct csp_sequential_composition  *seq = vseq;
+    struct csp_sequential_composition *seq = vseq;
     /* 1) P;Q can perform all of the same events as P, except for ✔.
      * 2) If P can perform ✔, then P;Q can perform τ.
      *
@@ -56,10 +56,10 @@ csp_sequential_composition_afters(struct csp *csp, csp_id initial,
      *
      * (Note that τ is covered by both rules)
      */
-    struct csp_sequential_composition  *seq = vseq;
-    size_t  i;
-    struct csp_id_set_builder  afters_builder;
-    struct csp_id_set  afters;
+    struct csp_sequential_composition *seq = vseq;
+    size_t i;
+    struct csp_id_set_builder afters_builder;
+    struct csp_id_set afters;
 
     /* The composition can never perform a ✔; that's always translated into a τ
      * that activates process Q. */
@@ -74,8 +74,8 @@ csp_sequential_composition_afters(struct csp *csp, csp_id initial,
     csp_process_build_afters(csp, seq->p, initial, &afters_builder);
     csp_id_set_build(&afters, &afters_builder);
     for (i = 0; i < afters.count; i++) {
-        csp_id  p_prime = afters.ids[i];
-        csp_id  seq_prime = csp_sequential_composition(csp, p_prime, seq->q);
+        csp_id p_prime = afters.ids[i];
+        csp_id seq_prime = csp_sequential_composition(csp, p_prime, seq->q);
         csp_id_set_builder_add(builder, seq_prime);
     }
 
@@ -98,9 +98,9 @@ csp_sequential_composition_afters(struct csp *csp, csp_id initial,
 static csp_id
 csp_sequential_composition_get_id(struct csp *csp, const void *vinput)
 {
-    const struct csp_sequential_composition  *input = vinput;
-    static struct csp_id_scope  sequential_composition;
-    csp_id  id = csp_id_start(&sequential_composition);
+    const struct csp_sequential_composition *input = vinput;
+    static struct csp_id_scope sequential_composition;
+    csp_id id = csp_id_start(&sequential_composition);
     id = csp_id_add_id(id, input->p);
     id = csp_id_add_id(id, input->q);
     return id;
@@ -115,8 +115,8 @@ csp_sequential_composition_ud_size(struct csp *csp, const void *vinput)
 static void
 csp_sequential_composition_init(struct csp *csp, void *vseq, const void *vinput)
 {
-    struct csp_sequential_composition  *seq = vseq;
-    const struct csp_sequential_composition  *input = vinput;
+    struct csp_sequential_composition *seq = vseq;
+    const struct csp_sequential_composition *input = vinput;
     seq->p = input->p;
     seq->q = input->q;
 }
@@ -127,19 +127,18 @@ csp_sequential_composition_done(struct csp *csp, void *vseq)
     /* nothing to do */
 }
 
-static const struct csp_process_iface  csp_sequential_composition_iface = {
-    &csp_sequential_composition_initials,
-    &csp_sequential_composition_afters,
-    &csp_sequential_composition_get_id,
-    &csp_sequential_composition_ud_size,
-    &csp_sequential_composition_init,
-    &csp_sequential_composition_done
-};
+static const struct csp_process_iface csp_sequential_composition_iface = {
+        &csp_sequential_composition_initials,
+        &csp_sequential_composition_afters,
+        &csp_sequential_composition_get_id,
+        &csp_sequential_composition_ud_size,
+        &csp_sequential_composition_init,
+        &csp_sequential_composition_done};
 
 csp_id
 csp_sequential_composition(struct csp *csp, csp_id p, csp_id q)
 {
-    struct csp_sequential_composition  input = { p, q };
-    return csp_process_init(
-            csp, &input, NULL, &csp_sequential_composition_iface);
+    struct csp_sequential_composition input = {p, q};
+    return csp_process_init(csp, &input, NULL,
+                            &csp_sequential_composition_iface);
 }

--- a/src/libhst/refinement.c
+++ b/src/libhst/refinement.c
@@ -9,45 +9,45 @@
 
 #if defined(REFINEMENT_DEBUG)
 #include <stdio.h>
-#define XDEBUG(...)  fprintf(stderr, __VA_ARGS__)
-#define XDEBUG_PROCESS_SET(set) \
-    do { \
-        bool  __first = true; \
-        size_t  __i; \
-        XDEBUG("{"); \
+#define XDEBUG(...) fprintf(stderr, __VA_ARGS__)
+#define XDEBUG_PROCESS_SET(set)                    \
+    do {                                           \
+        bool __first = true;                       \
+        size_t __i;                                \
+        XDEBUG("{");                               \
         for (__i = 0; __i < (set)->count; __i++) { \
-            if (__first) { \
-                __first = false; \
-            } else { \
-                XDEBUG(","); \
-            } \
-            XDEBUG(CSP_ID_FMT, (set)->ids[__i]); \
-        } \
-        XDEBUG("}"); \
+            if (__first) {                         \
+                __first = false;                   \
+            } else {                               \
+                XDEBUG(",");                       \
+            }                                      \
+            XDEBUG(CSP_ID_FMT, (set)->ids[__i]);   \
+        }                                          \
+        XDEBUG("}");                               \
     } while (0)
 #else
-#define XDEBUG(...)   /* do nothing */
-#define XDEBUG_PROCESS_SET(set)  /* do nothing */
+#define XDEBUG(...)             /* do nothing */
+#define XDEBUG_PROCESS_SET(set) /* do nothing */
 #endif
 
-#define DEBUG(...) \
-    do { \
+#define DEBUG(...)           \
+    do {                     \
         XDEBUG(__VA_ARGS__); \
-        XDEBUG("\n"); \
+        XDEBUG("\n");        \
     } while (0)
-#define DEBUG_PROCESS_SET(set) \
-    do { \
+#define DEBUG_PROCESS_SET(set)   \
+    do {                         \
         XDEBUG_PROCESS_SET(set); \
-        XDEBUG("\n"); \
+        XDEBUG("\n");            \
     } while (0)
 
 void
 csp_process_find_closure(struct csp *csp, csp_id event,
                          struct csp_id_set *processes)
 {
-    struct csp_id_set_builder  queue;
-    struct csp_id_set_builder  seen;
-    struct csp_id_set_builder  result;
+    struct csp_id_set_builder queue;
+    struct csp_id_set_builder seen;
+    struct csp_id_set_builder result;
     csp_id_set_builder_init(&queue);
     csp_id_set_builder_init(&seen);
     csp_id_set_builder_init(&result);
@@ -55,9 +55,9 @@ csp_process_find_closure(struct csp *csp, csp_id event,
     csp_id_set_builder_merge(&queue, processes);
     csp_id_set_build(processes, &queue);
     while (processes->count > 0) {
-        size_t  i;
+        size_t i;
         for (i = 0; i < processes->count; i++) {
-            csp_id  process = processes->ids[i];
+            csp_id process = processes->ids[i];
             DEBUG("process " CSP_ID_FMT, process);
             /* Don't handle this process more than once. */
             if (csp_id_set_builder_add(&seen, process)) {
@@ -82,12 +82,12 @@ csp_id
 csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
                          csp_id process)
 {
-    csp_id  node;
-    struct csp_id_set  closure;
-    struct csp_id_set  pending;
-    struct csp_id_set  initials;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set_builder  pending_builder;
+    csp_id node;
+    struct csp_id_set closure;
+    struct csp_id_set pending;
+    struct csp_id_set initials;
+    struct csp_id_set_builder builder;
+    struct csp_id_set_builder pending_builder;
     csp_id_set_init(&closure);
     csp_id_set_init(&pending);
     csp_id_set_init(&initials);
@@ -110,12 +110,12 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
 
     /* Keep processing normalized LTS nodes until we run out. */
     while (pending.count > 0) {
-        size_t  i;
+        size_t i;
         for (i = 0; i < pending.count; i++) {
-            size_t  j;
-            csp_id  current = pending.ids[i];
-            const struct csp_id_set  *current_processes =
-                csp_normalized_lts_get_node_processes(lts, current);
+            size_t j;
+            csp_id current = pending.ids[i];
+            const struct csp_id_set *current_processes =
+                    csp_normalized_lts_get_node_processes(lts, current);
             DEBUG("Process normalized node " CSP_ID_FMT, current);
             XDEBUG("representing processes ");
             DEBUG_PROCESS_SET(current_processes);
@@ -123,7 +123,7 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
             /* Find all of the non-τ events that any of the current processes
              * can perform. */
             for (j = 0; j < current_processes->count; j++) {
-                csp_id  process = current_processes->ids[j];
+                csp_id process = current_processes->ids[j];
                 DEBUG("Get initials of " CSP_ID_FMT, process);
                 csp_process_build_initials(csp, process, &builder);
             }
@@ -135,12 +135,12 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
             /* For each of those events, union together the `afters` of that
              * event for all of the processes in the current set. */
             for (j = 0; j < initials.count; j++) {
-                size_t  k;
-                csp_id  initial = initials.ids[j];
-                csp_id  after;
+                size_t k;
+                csp_id initial = initials.ids[j];
+                csp_id after;
                 DEBUG("Get afters for " CSP_ID_FMT, initial);
                 for (k = 0; k < current_processes->count; k++) {
-                    csp_id  process = current_processes->ids[k];
+                    csp_id process = current_processes->ids[k];
                     DEBUG("Get afters of " CSP_ID_FMT " for " CSP_ID_FMT,
                           process, initial);
                     csp_process_build_afters(csp, process, initial, &builder);

--- a/tests/test-case-harness.h
+++ b/tests/test-case-harness.h
@@ -14,7 +14,8 @@
  * Harness
  */
 
-int main(void)
+int
+main(void)
 {
     run_tests();
     return exit_status();

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -41,15 +41,16 @@
  * Cleaning up test cases
  */
 
-typedef void test_case_cleanup_f(void *);
+typedef void
+test_case_cleanup_f(void *);
 
 struct test_case_cleanup {
-    test_case_cleanup_f  *func;
-    void  *ud;
-    struct test_case_cleanup  *next;
+    test_case_cleanup_f *func;
+    void *ud;
+    struct test_case_cleanup *next;
 };
 
-static struct test_case_cleanup  *cleanup_routines;
+static struct test_case_cleanup *cleanup_routines;
 
 static void
 test_case_cleanup_start(void)
@@ -61,8 +62,8 @@ UNNEEDED
 static void
 test_case_cleanup_register(test_case_cleanup_f *func, void *ud)
 {
-    struct test_case_cleanup  *routine =
-        malloc(sizeof(struct test_case_cleanup));
+    struct test_case_cleanup *routine =
+            malloc(sizeof(struct test_case_cleanup));
     assert(routine != NULL);
     routine->func = func;
     routine->ud = ud;
@@ -73,8 +74,8 @@ test_case_cleanup_register(test_case_cleanup_f *func, void *ud)
 static void
 test_case_cleanup_finish(void)
 {
-    struct test_case_cleanup  *curr;
-    struct test_case_cleanup  *next;
+    struct test_case_cleanup *curr;
+    struct test_case_cleanup *next;
     for (curr = cleanup_routines; curr != NULL; curr = next) {
         next = curr->next;
         curr->func(curr->ud);
@@ -87,7 +88,7 @@ test_case_cleanup_finish(void)
  * Test cases
  */
 
-#define MAX_TEST_CASE_COUNT  100
+#define MAX_TEST_CASE_COUNT 100
 
 /* Each descriptor defines either a test case or a test comment.  For a test
  * comment, we just display the description as a comment, and do nothing else.
@@ -98,14 +99,14 @@ test_case_cleanup_finish(void)
  * print the test case's description as a comment. */
 
 struct test_case_descriptor {
-    struct test_case_descriptor  *next;
+    struct test_case_descriptor *next;
     void (*function)(void);
-    const char  *description;
-    unsigned int  line;
+    const char *description;
+    unsigned int line;
 };
 
-static struct test_case_descriptor  *test_cases[MAX_TEST_CASE_COUNT];
-static unsigned int  test_case_descriptor_count = 0;
+static struct test_case_descriptor *test_cases[MAX_TEST_CASE_COUNT];
+static unsigned int test_case_descriptor_count = 0;
 
 static void
 register_test_case(struct test_case_descriptor *test)
@@ -115,56 +116,44 @@ register_test_case(struct test_case_descriptor *test)
 }
 
 
-#define TEST_CASE(description)           TEST_CASE_AT(description, __LINE__)
-#define TEST_CASE_AT(description, line)  TEST_CASE_AT_(description, line)
-#define TEST_CASE_AT_(description, line) \
-static void \
-test_case__##line(void); \
-\
-static struct test_case_descriptor test_case_##line = { \
-    NULL, \
-    test_case__##line, \
-    description, \
-    line \
-}; \
-\
-CONSTRUCTOR \
-static void \
-register_test_case_##line(void) \
-{ \
-    register_test_case(&test_case_##line); \
-} \
-\
-static void \
-test_case__##line(void)
+#define TEST_CASE(description) TEST_CASE_AT(description, __LINE__)
+#define TEST_CASE_AT(description, line) TEST_CASE_AT_(description, line)
+#define TEST_CASE_AT_(description, line)                    \
+    static void test_case__##line(void);                    \
+                                                            \
+    static struct test_case_descriptor test_case_##line = { \
+            NULL, test_case__##line, description, line};    \
+                                                            \
+    CONSTRUCTOR                                             \
+    static void register_test_case_##line(void)             \
+    {                                                       \
+        register_test_case(&test_case_##line);              \
+    }                                                       \
+                                                            \
+    static void test_case__##line(void)
 
 
-#define TEST_CASE_GROUP(desc)           TEST_CASE_GROUP_AT(desc, __LINE__)
-#define TEST_CASE_GROUP_AT(desc, line)  TEST_CASE_GROUP_AT_(desc, line)
-#define TEST_CASE_GROUP_AT_(description, line) \
-static struct test_case_descriptor test_case_group_##line = { \
-    NULL, \
-    NULL, \
-    description, \
-    line \
-}; \
-\
-CONSTRUCTOR \
-static void \
-register_test_case_group_##line(void) \
-{ \
-    register_test_case(&test_case_group_##line); \
-}
+#define TEST_CASE_GROUP(desc) TEST_CASE_GROUP_AT(desc, __LINE__)
+#define TEST_CASE_GROUP_AT(desc, line) TEST_CASE_GROUP_AT_(desc, line)
+#define TEST_CASE_GROUP_AT_(description, line)                    \
+    static struct test_case_descriptor test_case_group_##line = { \
+            NULL, NULL, description, line};                       \
+                                                                  \
+    CONSTRUCTOR                                                   \
+    static void register_test_case_group_##line(void)             \
+    {                                                             \
+        register_test_case(&test_case_group_##line);              \
+    }
 
 
-static struct test_case_descriptor  *current_test_case;
-static unsigned int  test_case_number;
-static bool  test_case_failed;
-static bool  any_test_case_failed;
+static struct test_case_descriptor *current_test_case;
+static unsigned int test_case_number;
+static bool test_case_failed;
+static bool any_test_case_failed;
 
 UNNEEDED
 static void
-vfail_at(const char* filename, unsigned int line, const char* fmt, va_list args)
+vfail_at(const char *filename, unsigned int line, const char *fmt, va_list args)
 {
     if (!test_case_failed) {
         printf("not ok %u - %s\n", test_case_number,
@@ -179,15 +168,15 @@ vfail_at(const char* filename, unsigned int line, const char* fmt, va_list args)
 
 UNNEEDED
 static void
-fail_at(const char* filename, unsigned int line, const char* fmt, ...)
+fail_at(const char *filename, unsigned int line, const char *fmt, ...)
 {
-    va_list  args;
+    va_list args;
     va_start(args, fmt);
     vfail_at(filename, line, fmt, args);
     va_end(args);
 }
 
-static jmp_buf  test_case_return;
+static jmp_buf test_case_return;
 
 static void
 run_test(struct test_case_descriptor *test)
@@ -219,8 +208,8 @@ abort_test(void)
 static int
 compare_test_cases(const void *vtest1, const void *vtest2)
 {
-    const struct test_case_descriptor * const  *test1 = vtest1;
-    const struct test_case_descriptor * const  *test2 = vtest2;
+    const struct test_case_descriptor *const *test1 = vtest1;
+    const struct test_case_descriptor *const *test2 = vtest2;
     if ((*test1)->line < (*test2)->line) {
         return -1;
     } else if ((*test1)->line == (*test2)->line) {
@@ -233,8 +222,8 @@ compare_test_cases(const void *vtest1, const void *vtest2)
 static unsigned int
 count_test_cases(void)
 {
-    unsigned int  i;
-    unsigned int  count = 0;
+    unsigned int i;
+    unsigned int count = 0;
     for (i = 0; i < test_case_descriptor_count; i++) {
         if (test_cases[i]->function != NULL) {
             count++;
@@ -246,7 +235,7 @@ count_test_cases(void)
 static void
 run_tests(void)
 {
-    unsigned int  i;
+    unsigned int i;
     qsort(test_cases, test_case_descriptor_count,
           sizeof(struct test_case_descriptor *), compare_test_cases);
     printf("1..%u\n", count_test_cases());
@@ -260,7 +249,7 @@ run_tests(void)
 static int
 exit_status(void)
 {
-    return any_test_case_failed? 1: 0;
+    return any_test_case_failed ? 1 : 0;
 }
 
 /*-----------------------------------------------------------------------------
@@ -276,7 +265,7 @@ exit_status(void)
  *
  *     x(__FILE__, __LINE__, 1, 2)
  */
-#define ADD_FILE_AND_LINE(m)  m ADD_FILE_AND_LINE_
+#define ADD_FILE_AND_LINE(m) m ADD_FILE_AND_LINE_
 #define ADD_FILE_AND_LINE_(...) (__FILE__, __LINE__, __VA_ARGS__)
 
 /* Expands to the length of __VA_ARGS__ */
@@ -287,15 +276,15 @@ exit_status(void)
  * Check macros
  */
 
-#define fail  ADD_FILE_AND_LINE(fail_at)
+#define fail ADD_FILE_AND_LINE(fail_at)
 
-#define check_alloc_with_msg(var, call, ...) \
-    do { \
-        var = call; \
-        if (unlikely(var == NULL)) { \
+#define check_alloc_with_msg(var, call, ...)          \
+    do {                                              \
+        var = call;                                   \
+        if (unlikely(var == NULL)) {                  \
             fail_at(__FILE__, __LINE__, __VA_ARGS__); \
-            abort_test(); \
-        } \
+            abort_test();                             \
+        }                                             \
     } while (0)
 
 #define check_alloc(var, call) \
@@ -307,15 +296,15 @@ check_with_msg_(const char *filename, unsigned int line, bool result,
                 const char *fmt, ...)
 {
     if (unlikely(!result)) {
-        va_list  args;
+        va_list args;
         va_start(args, fmt);
         vfail_at(filename, line, fmt, args);
         va_end(args);
         abort_test();
     }
 }
-#define check_with_msg  ADD_FILE_AND_LINE(check_with_msg_)
-#define check(call)  check_with_msg(call, "Error occurred")
+#define check_with_msg ADD_FILE_AND_LINE(check_with_msg_)
+#define check(call) check_with_msg(call, "Error occurred")
 
 UNNEEDED
 static void
@@ -323,15 +312,15 @@ check0_with_msg_(const char *filename, unsigned int line, int result,
                  const char *fmt, ...)
 {
     if (unlikely(result != 0)) {
-        va_list  args;
+        va_list args;
         va_start(args, fmt);
         vfail_at(filename, line, fmt, args);
         va_end(args);
         abort_test();
     }
 }
-#define check0_with_msg  ADD_FILE_AND_LINE(check0_with_msg_)
-#define check0(call)  check0_with_msg(call, "Error occurred")
+#define check0_with_msg ADD_FILE_AND_LINE(check0_with_msg_)
+#define check0(call) check0_with_msg(call, "Error occurred")
 
 UNNEEDED
 static void
@@ -339,15 +328,15 @@ checkx0_with_msg_(const char *filename, unsigned int line, int result,
                   const char *fmt, ...)
 {
     if (unlikely(result == 0)) {
-        va_list  args;
+        va_list args;
         va_start(args, fmt);
         vfail_at(filename, line, fmt, args);
         va_end(args);
         abort_test();
     }
 }
-#define checkx0_with_msg  ADD_FILE_AND_LINE(checkx0_with_msg_)
-#define checkx0(call)  checkx0_with_msg(call, "Error should have occurred")
+#define checkx0_with_msg ADD_FILE_AND_LINE(checkx0_with_msg_)
+#define checkx0(call) checkx0_with_msg(call, "Error should have occurred")
 
 UNNEEDED
 static void
@@ -355,34 +344,35 @@ check_nonnull_with_msg_(const char *filename, unsigned int line, void *result,
                         const char *fmt, ...)
 {
     if (unlikely(result == NULL)) {
-        va_list  args;
+        va_list args;
         va_start(args, fmt);
         vfail_at(filename, line, fmt, args);
         va_end(args);
         abort_test();
     }
 }
-#define check_nonnull_with_msg  ADD_FILE_AND_LINE(check_nonnull_with_msg_)
-#define check_nonnull(call)  check_nonnull_with_msg(call, "Error occurred")
+#define check_nonnull_with_msg ADD_FILE_AND_LINE(check_nonnull_with_msg_)
+#define check_nonnull(call) check_nonnull_with_msg(call, "Error occurred")
 
 UNNEEDED
 static void
 check_id_eq_(const char *filename, unsigned int line, csp_id id1, csp_id id2)
 {
     check_with_msg_(filename, line, (id1 == id2),
-            "Expected IDs to be equal, got " CSP_ID_FMT " and " CSP_ID_FMT,
-            id1, id2);
+                    "Expected IDs to be equal, got " CSP_ID_FMT
+                    " and " CSP_ID_FMT,
+                    id1, id2);
 }
-#define check_id_eq  ADD_FILE_AND_LINE(check_id_eq_)
+#define check_id_eq ADD_FILE_AND_LINE(check_id_eq_)
 
 UNNEEDED
 static void
 check_id_ne_(const char *filename, unsigned int line, csp_id id1, csp_id id2)
 {
     check_with_msg_(filename, line, (id1 != id2),
-            "Expected IDs to be unequal, got " CSP_ID_FMT, id1);
+                    "Expected IDs to be unequal, got " CSP_ID_FMT, id1);
 }
-#define check_id_ne  ADD_FILE_AND_LINE(check_id_ne_)
+#define check_id_ne ADD_FILE_AND_LINE(check_id_ne_)
 
 UNNEEDED
 static void
@@ -390,9 +380,9 @@ check_streq_(const char *filename, unsigned int line, const char *actual,
              const char *expected)
 {
     check_with_msg_(filename, line, strcmp(actual, expected) == 0,
-            "Expected \"%s\", got \"%s\"", expected, actual);
+                    "Expected \"%s\", got \"%s\"", expected, actual);
 }
-#define check_streq  ADD_FILE_AND_LINE(check_streq_)
+#define check_streq ADD_FILE_AND_LINE(check_streq_)
 
 UNNEEDED
 static void
@@ -401,9 +391,9 @@ check_set_eq_(const char *filename, unsigned int line,
               const struct csp_id_set *expected)
 {
     if (unlikely(!csp_id_set_eq(actual, expected))) {
-        size_t  i;
-        struct csp_id_set_builder  builder;
-        struct csp_id_set  diff;
+        size_t i;
+        struct csp_id_set_builder builder;
+        struct csp_id_set diff;
         fail_at(filename, line, "Expected sets to be equal");
         printf("# hash of actual   = " CSP_ID_FMT "\n", actual->hash);
         printf("# hash of expected = " CSP_ID_FMT "\n", expected->hash);
@@ -413,7 +403,7 @@ check_set_eq_(const char *filename, unsigned int line,
         printf("# Elements only in actual:\n");
         csp_id_set_builder_merge(&builder, expected);
         for (i = 0; i < actual->count; i++) {
-            csp_id  curr = actual->ids[i];
+            csp_id curr = actual->ids[i];
             if (!csp_id_set_builder_remove(&builder, curr)) {
                 printf("#   " CSP_ID_FMT "\n", curr);
             }
@@ -423,7 +413,7 @@ check_set_eq_(const char *filename, unsigned int line,
         printf("# Elements only in expected:\n");
         csp_id_set_builder_merge(&builder, actual);
         for (i = 0; i < expected->count; i++) {
-            csp_id  curr = expected->ids[i];
+            csp_id curr = expected->ids[i];
             if (!csp_id_set_builder_remove(&builder, curr)) {
                 printf("#   " CSP_ID_FMT "\n", curr);
             }
@@ -435,7 +425,7 @@ check_set_eq_(const char *filename, unsigned int line,
         abort_test();
     }
 }
-#define check_set_eq  ADD_FILE_AND_LINE(check_set_eq_)
+#define check_set_eq ADD_FILE_AND_LINE(check_set_eq_)
 
 /*-----------------------------------------------------------------------------
  * Data constructors
@@ -445,7 +435,7 @@ UNNEEDED
 static void
 csp_id_set_free_(void *vset)
 {
-    struct csp_id_set  *set = vset;
+    struct csp_id_set *set = vset;
     csp_id_set_done(set);
     free(set);
 }
@@ -456,7 +446,7 @@ UNNEEDED
 static struct csp_id_set *
 empty_set(void)
 {
-    struct csp_id_set  *set = malloc(sizeof(struct csp_id_set));
+    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
     assert(set != NULL);
     csp_id_set_init(set);
     test_case_cleanup_register(csp_id_set_free_, set);
@@ -465,26 +455,25 @@ empty_set(void)
 
 /* Creates a new set containing the given IDs.  The set will be automatically
  * freed for you at the end of the test case. */
-#define id_set(...) \
+#define id_set(...)                                 \
     CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
-        (id_set_(LENGTH(__VA_ARGS__), __VA_ARGS__)) \
-        (empty_set())
+    (id_set_(LENGTH(__VA_ARGS__), __VA_ARGS__))(empty_set())
 
 UNNEEDED
 static struct csp_id_set *
 id_set_(size_t count, ...)
 {
-    size_t  i;
-    va_list  args;
-    struct csp_id_set  *set = malloc(sizeof(struct csp_id_set));
-    struct csp_id_set_builder  builder;
+    size_t i;
+    va_list args;
+    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
+    struct csp_id_set_builder builder;
     assert(set != NULL);
     csp_id_set_init(set);
     test_case_cleanup_register(csp_id_set_free_, set);
     csp_id_set_builder_init(&builder);
     va_start(args, count);
     for (i = 0; i < count; i++) {
-        csp_id  id = va_arg(args, csp_id);
+        csp_id id = va_arg(args, csp_id);
         csp_id_set_builder_add(&builder, id);
     }
     va_end(args);
@@ -499,9 +488,9 @@ UNNEEDED
 static struct csp_id_set *
 id_range_set(size_t start, size_t end)
 {
-    size_t  i;
-    struct csp_id_set  *set = malloc(sizeof(struct csp_id_set));
-    struct csp_id_set_builder  builder;
+    size_t i;
+    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
+    struct csp_id_set_builder builder;
     assert(set != NULL);
     csp_id_set_init(set);
     test_case_cleanup_register(csp_id_set_free_, set);
@@ -517,30 +506,29 @@ id_range_set(size_t start, size_t end)
 /* Creates a new array of strings.  The set (but not the strings in the array)
  * will be automatically freed for you at the end of the test case. */
 struct string_array {
-    size_t  count;
-    const char  **strings;
+    size_t count;
+    const char **strings;
 };
 
-#define strings(...) \
+#define strings(...)                                \
     CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
-        (strings_(LENGTH(__VA_ARGS__), __VA_ARGS__)) \
-        (strings_(0, NULL))
+    (strings_(LENGTH(__VA_ARGS__), __VA_ARGS__))(strings_(0, NULL))
 
 UNNEEDED
 static struct string_array *
 strings_(size_t count, ...)
 {
-    size_t  i;
-    size_t  size = (count * sizeof(const char *)) + sizeof(struct string_array);
-    va_list  args;
-    struct string_array  *array = malloc(size);
+    size_t i;
+    size_t size = (count * sizeof(const char *)) + sizeof(struct string_array);
+    va_list args;
+    struct string_array *array = malloc(size);
     assert(array != NULL);
     test_case_cleanup_register(free, array);
     array->count = count;
     array->strings = (void *) (array + 1);
     va_start(args, count);
     for (i = 0; i < count; i++) {
-        const char  *string = va_arg(args, const char *);
+        const char *string = va_arg(args, const char *);
         array->strings[i] = string;
     }
     va_end(args);
@@ -553,7 +541,7 @@ strings_(size_t count, ...)
  * environment object available. */
 struct csp_id_factory {
     csp_id (*create)(struct csp *csp, void *ud);
-    void  *ud;
+    void *ud;
 };
 
 UNNEEDED
@@ -569,7 +557,7 @@ csp_id_factory_create(struct csp *csp, struct csp_id_factory factory)
  * have a CSP environment object available. */
 struct csp_id_set_factory {
     struct csp_id_set *(*create)(struct csp *csp, void *ud);
-    void  *ud;
+    void *ud;
 };
 
 UNNEEDED
@@ -587,7 +575,7 @@ event(const char *event_name);
 static csp_id
 event_factory(struct csp *csp, void *vevent_name)
 {
-    const char  *event_name = vevent_name;
+    const char *event_name = vevent_name;
     return csp_get_event_id(csp, event_name);
 }
 
@@ -595,28 +583,28 @@ UNNEEDED
 static struct csp_id_factory
 event(const char *event_name)
 {
-    struct csp_id_factory  factory = { event_factory, (void *) event_name };
+    struct csp_id_factory factory = {event_factory, (void *) event_name};
     return factory;
 }
 
 /* Creates a new set factory that creates a set containing the given events.
  * The set will be automatically freed for you at the end of the test case. */
-#define events(...)  events_(strings(__VA_ARGS__))
+#define events(...) events_(strings(__VA_ARGS__))
 
 static struct csp_id_set *
 events_factory(struct csp *csp, void *vnames)
 {
-    struct string_array  *names = vnames;
-    size_t  i;
-    struct csp_id_set  *set = malloc(sizeof(struct csp_id_set));
-    struct csp_id_set_builder  builder;
+    struct string_array *names = vnames;
+    size_t i;
+    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
+    struct csp_id_set_builder builder;
     assert(set != NULL);
     csp_id_set_init(set);
     test_case_cleanup_register(csp_id_set_free_, set);
     csp_id_set_builder_init(&builder);
     for (i = 0; i < names->count; i++) {
-        const char  *event_name = names->strings[i];
-        csp_id  event = csp_get_event_id(csp, event_name);
+        const char *event_name = names->strings[i];
+        csp_id event = csp_get_event_id(csp, event_name);
         csp_id_set_builder_add(&builder, event);
     }
     csp_id_set_build(set, &builder);
@@ -628,7 +616,7 @@ UNNEEDED
 static struct csp_id_set_factory
 events_(struct string_array *names)
 {
-    struct csp_id_set_factory  factory = { events_factory, names };
+    struct csp_id_set_factory factory = {events_factory, names};
     return factory;
 }
 
@@ -640,8 +628,8 @@ csp0(const char *csp0);
 static csp_id
 csp0_factory(struct csp *csp, void *vcsp0)
 {
-    const char  *csp0 = vcsp0;
-    csp_id  process;
+    const char *csp0 = vcsp0;
+    csp_id process;
     check0(csp_load_csp0_string(csp, csp0, &process));
     return process;
 }
@@ -650,29 +638,29 @@ UNNEEDED
 static struct csp_id_factory
 csp0(const char *csp0)
 {
-    struct csp_id_factory  factory = { csp0_factory, (void *) csp0 };
+    struct csp_id_factory factory = {csp0_factory, (void *) csp0};
     return factory;
 }
 
 /* Creates a new set factory that creates a set containing the given CSP₀
  * processes.  The set will be automatically freed for you at the end of the
  * test case. */
-#define csp0s(...)  csp0s_(strings(__VA_ARGS__))
+#define csp0s(...) csp0s_(strings(__VA_ARGS__))
 
 static struct csp_id_set *
 csp0s_factory(struct csp *csp, void *vprocesses)
 {
-    struct string_array  *processes = vprocesses;
-    size_t  i;
-    struct csp_id_set  *set = malloc(sizeof(struct csp_id_set));
-    struct csp_id_set_builder  builder;
+    struct string_array *processes = vprocesses;
+    size_t i;
+    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
+    struct csp_id_set_builder builder;
     assert(set != NULL);
     csp_id_set_init(set);
     test_case_cleanup_register(csp_id_set_free_, set);
     csp_id_set_builder_init(&builder);
     for (i = 0; i < processes->count; i++) {
-        const char  *csp0 = processes->strings[i];
-        csp_id  process;
+        const char *csp0 = processes->strings[i];
+        csp_id process;
         check0(csp_load_csp0_string(csp, csp0, &process));
         csp_id_set_builder_add(&builder, process);
     }
@@ -685,7 +673,7 @@ UNNEEDED
 static struct csp_id_set_factory
 csp0s_(struct string_array *processes)
 {
-    struct csp_id_set_factory  factory = { csp0s_factory, processes };
+    struct csp_id_set_factory factory = {csp0s_factory, processes};
     return factory;
 }
 

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -8,37 +8,38 @@
 #include <string.h>
 
 #include "hst.h"
-#include "test-cases.h"
 #include "test-case-harness.h"
+#include "test-cases.h"
 
 /* Don't check the semantics of any of the operators here; this file just checks
  * that the CSP₀ parser produces the same processes that you'd get constructing
  * things by hand.  Look in test-operators.c for test cases that verify that
  * each operator behaves as we expect it to. */
 
-#define check_csp0_eq(str, expected) \
-    do { \
-        csp_id  __actual; \
+#define check_csp0_eq(str, expected)                         \
+    do {                                                     \
+        csp_id __actual;                                     \
         check0(csp_load_csp0_string(csp, (str), &__actual)); \
-        check_id_eq(__actual, (expected)); \
+        check_id_eq(__actual, (expected));                   \
     } while (0)
 
-#define check_csp0_valid(str) \
-    do { \
-        csp_id  __actual; \
+#define check_csp0_valid(str)                                \
+    do {                                                     \
+        csp_id __actual;                                     \
         check0(csp_load_csp0_string(csp, (str), &__actual)); \
     } while (0)
 
-#define check_csp0_invalid(str) \
-    do { \
-        csp_id  __actual; \
+#define check_csp0_invalid(str)                               \
+    do {                                                      \
+        csp_id __actual;                                      \
         checkx0(csp_load_csp0_string(csp, (str), &__actual)); \
     } while (0)
 
 TEST_CASE_GROUP("CSP₀ syntax");
 
-TEST_CASE("can parse identifiers") {
-    struct csp  *csp;
+TEST_CASE("can parse identifiers")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Parse a bunch of valid identifiers. */
@@ -68,8 +69,9 @@ TEST_CASE("can parse identifiers") {
     csp_free(csp);
 }
 
-TEST_CASE("can parse debug recursion identifiers") {
-    struct csp  *csp;
+TEST_CASE("can parse debug recursion identifiers")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Parse a bunch of valid identifiers. */
@@ -86,8 +88,9 @@ TEST_CASE("can parse debug recursion identifiers") {
 
 TEST_CASE_GROUP("CSP₀ primitives");
 
-TEST_CASE("parse: STOP") {
-    struct csp  *csp;
+TEST_CASE("parse: STOP")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Verify that we can parse the process, with and without whitespace. */
@@ -99,8 +102,9 @@ TEST_CASE("parse: STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: SKIP") {
-    struct csp  *csp;
+TEST_CASE("parse: SKIP")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Verify that we can parse the process, with and without whitespace. */
@@ -114,15 +118,16 @@ TEST_CASE("parse: SKIP") {
 
 TEST_CASE_GROUP("CSP₀ operators");
 
-TEST_CASE("parse: a → STOP □ SKIP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  p0;
-    csp_id  root;
+TEST_CASE("parse: a → STOP □ SKIP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id p0;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
-    p0 = csp_prefix(csp, a,  csp->stop);
+    p0 = csp_prefix(csp, a, csp->stop);
     root = csp_external_choice(csp, p0, csp->skip);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a->STOP[]SKIP", root);
@@ -147,16 +152,17 @@ TEST_CASE("parse: a → STOP □ SKIP") {
     csp_free(csp);
 }
 
-TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  c;
-    csp_id  p1;
-    csp_id  p2;
-    csp_id  p3;
-    csp_id  p4;
-    csp_id  root;
+TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id c;
+    csp_id p1;
+    csp_id p2;
+    csp_id p3;
+    csp_id p4;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -174,11 +180,12 @@ TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: a → STOP ⊓ SKIP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  p1;
-    csp_id  root;
+TEST_CASE("parse: a → STOP ⊓ SKIP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id p1;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -207,16 +214,17 @@ TEST_CASE("parse: a → STOP ⊓ SKIP") {
     csp_free(csp);
 }
 
-TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  c;
-    csp_id  p1;
-    csp_id  p2;
-    csp_id  p3;
-    csp_id  p4;
-    csp_id  root;
+TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id c;
+    csp_id p1;
+    csp_id p2;
+    csp_id p3;
+    csp_id p4;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -234,8 +242,9 @@ TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: (STOP)") {
-    struct csp  *csp;
+TEST_CASE("parse: (STOP)")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Verify that we can parse the process, with and without whitespace. */
@@ -250,10 +259,11 @@ TEST_CASE("parse: (STOP)") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: a → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  root;
+TEST_CASE("parse: a → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -280,12 +290,13 @@ TEST_CASE("parse: a → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("associativity: a → b → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  p;
-    csp_id  root;
+TEST_CASE("associativity: a → b → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id p;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -299,8 +310,9 @@ TEST_CASE("associativity: a → b → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: let X = a → STOP within X") {
-    struct csp  *csp;
+TEST_CASE("parse: let X = a → STOP within X")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Verify that we can parse the process, with and without whitespace. */
@@ -320,8 +332,9 @@ TEST_CASE("parse: let X = a → STOP within X") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: let X = a → Y Y = b → X within X") {
-    struct csp  *csp;
+TEST_CASE("parse: let X = a → Y Y = b → X within X")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Verify that we can parse the process, with and without whitespace. */
@@ -340,11 +353,12 @@ TEST_CASE("parse: let X = a → Y Y = b → X within X") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: □ {a → STOP, SKIP}") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  p1;
-    csp_id  root;
+TEST_CASE("parse: □ {a → STOP, SKIP}")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id p1;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -386,11 +400,12 @@ TEST_CASE("parse: □ {a → STOP, SKIP}") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: ⊓ {a → STOP, SKIP}") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  p1;
-    csp_id  root;
+TEST_CASE("parse: ⊓ {a → STOP, SKIP}")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id p1;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -432,11 +447,12 @@ TEST_CASE("parse: ⊓ {a → STOP, SKIP}") {
     csp_free(csp);
 }
 
-TEST_CASE("parse: a → SKIP ; STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  p1;
-    csp_id  root;
+TEST_CASE("parse: a → SKIP ; STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id p1;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -462,16 +478,17 @@ TEST_CASE("parse: a → SKIP ; STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  c;
-    csp_id  p1;
-    csp_id  p2;
-    csp_id  p3;
-    csp_id  p4;
-    csp_id  root;
+TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id c;
+    csp_id p1;
+    csp_id p2;
+    csp_id p3;
+    csp_id p4;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     a = csp_get_event_id(csp, "a");
@@ -488,16 +505,17 @@ TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP") {
     csp_free(csp);
 }
 
-TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  c;
-    csp_id  p1;
-    csp_id  p2;
-    csp_id  p3;
-    csp_id  p4;
-    csp_id  root;
+TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id c;
+    csp_id p1;
+    csp_id p2;
+    csp_id p3;
+    csp_id p4;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Expected result is
@@ -517,16 +535,17 @@ TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("precedence: a → STOP □ b → SKIP ; c → STOP") {
-    struct csp  *csp;
-    csp_id  a;
-    csp_id  b;
-    csp_id  c;
-    csp_id  p1;
-    csp_id  p2;
-    csp_id  p3;
-    csp_id  p4;
-    csp_id  root;
+TEST_CASE("precedence: a → STOP □ b → SKIP ; c → STOP")
+{
+    struct csp *csp;
+    csp_id a;
+    csp_id b;
+    csp_id c;
+    csp_id p1;
+    csp_id p2;
+    csp_id p3;
+    csp_id p4;
+    csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* Expected result is

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -8,23 +8,25 @@
 #include <string.h>
 
 #include "hst.h"
-#include "test-cases.h"
 #include "test-case-harness.h"
+#include "test-cases.h"
 
 TEST_CASE_GROUP("environments");
 
-TEST_CASE("predefined events exist") {
-    static const char* const TAU = "τ";
-    static const char* const TICK = "✔";
-    struct csp  *csp;
+TEST_CASE("predefined events exist")
+{
+    static const char *const TAU = "τ";
+    static const char *const TICK = "✔";
+    struct csp *csp;
     check_alloc(csp, csp_new());
     check_streq(csp_get_event_name(csp, csp->tau), TAU);
     check_streq(csp_get_event_name(csp, csp->tick), TICK);
     csp_free(csp);
 }
 
-TEST_CASE("can create events") {
-    struct csp  *csp;
+TEST_CASE("can create events")
+{
+    struct csp *csp;
     check_alloc(csp, csp_new());
     check_with_msg(csp_get_event_name(csp, 0) == NULL,
                    "Should get a name for undefined event");
@@ -37,10 +39,11 @@ TEST_CASE("can create events") {
     csp_free(csp);
 }
 
-TEST_CASE("predefined STOP process exists") {
-    struct csp  *csp;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("predefined STOP process exists")
+{
+    struct csp *csp;
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     /* Create the CSP environment. */
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
@@ -63,10 +66,11 @@ TEST_CASE("predefined STOP process exists") {
     csp_free(csp);
 }
 
-TEST_CASE("predefined SKIP process exists") {
-    struct csp  *csp;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("predefined SKIP process exists")
+{
+    struct csp *csp;
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     /* Create the CSP environment. */
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
@@ -89,65 +93,73 @@ TEST_CASE("predefined SKIP process exists") {
     csp_free(csp);
 }
 
-TEST_CASE("base process IDs should be reproducible") {
-    static struct csp_id_scope  scope;
+TEST_CASE("base process IDs should be reproducible")
+{
+    static struct csp_id_scope scope;
     check_id_eq(csp_id_start(&scope), csp_id_start(&scope));
 }
 
-TEST_CASE("distinct scopes should produce different IDs") {
-    static struct csp_id_scope  scope1;
-    static struct csp_id_scope  scope2;
+TEST_CASE("distinct scopes should produce different IDs")
+{
+    static struct csp_id_scope scope1;
+    static struct csp_id_scope scope2;
     check_id_ne(csp_id_start(&scope1), csp_id_start(&scope2));
 }
 
-TEST_CASE("ID-derived process IDs should be reproducible") {
-    static struct csp_id_scope  scope;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("ID-derived process IDs should be reproducible")
+{
+    static struct csp_id_scope scope;
+    csp_id base = csp_id_start(&scope);
     check_id_eq(csp_id_add_id(base, 0), csp_id_add_id(base, 0));
     check_id_eq(csp_id_add_id(base, 10), csp_id_add_id(base, 10));
     check_id_eq(csp_id_add_id(base, 100), csp_id_add_id(base, 100));
 }
 
-TEST_CASE("distinct IDs should produce different IDs") {
-    static struct csp_id_scope  scope;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("distinct IDs should produce different IDs")
+{
+    static struct csp_id_scope scope;
+    csp_id base = csp_id_start(&scope);
     check_id_ne(csp_id_add_id(base, 0), csp_id_add_id(base, 10));
     check_id_ne(csp_id_add_id(base, 0), csp_id_add_id(base, 100));
     check_id_ne(csp_id_add_id(base, 10), csp_id_add_id(base, 100));
 }
 
-TEST_CASE("set-derived process IDs should be reproducible") {
-    static struct csp_id_scope  scope;
-    struct csp_id_set  *set1;
-    struct csp_id_set  *set2;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("set-derived process IDs should be reproducible")
+{
+    static struct csp_id_scope scope;
+    struct csp_id_set *set1;
+    struct csp_id_set *set2;
+    csp_id base = csp_id_start(&scope);
     set1 = id_set(1, 2, 3, 4);
     set2 = id_set(1, 2, 3, 4);
     check_id_eq(csp_id_add_id_set(base, set1), csp_id_add_id_set(base, set1));
     check_id_eq(csp_id_add_id_set(base, set1), csp_id_add_id_set(base, set2));
 }
 
-TEST_CASE("distinct sets should produce different IDs") {
-    static struct csp_id_scope  scope;
-    struct csp_id_set  *set1;
-    struct csp_id_set  *set2;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("distinct sets should produce different IDs")
+{
+    static struct csp_id_scope scope;
+    struct csp_id_set *set1;
+    struct csp_id_set *set2;
+    csp_id base = csp_id_start(&scope);
     set1 = id_set(1, 2, 3, 4);
     set2 = id_set(5, 6, 7, 8);
     check_id_ne(csp_id_add_id_set(base, set1), csp_id_add_id_set(base, set2));
 }
 
-TEST_CASE("name-derived process IDs should be reproducible") {
-    static struct csp_id_scope  scope;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("name-derived process IDs should be reproducible")
+{
+    static struct csp_id_scope scope;
+    csp_id base = csp_id_start(&scope);
     check_id_eq(csp_id_add_name(base, "a"), csp_id_add_name(base, "a"));
     check_id_eq(csp_id_add_name(base, "b"), csp_id_add_name(base, "b"));
     check_id_eq(csp_id_add_name(base, "c"), csp_id_add_name(base, "c"));
 }
 
-TEST_CASE("distinct names should produce different IDs") {
-    static struct csp_id_scope  scope;
-    csp_id  base = csp_id_start(&scope);
+TEST_CASE("distinct names should produce different IDs")
+{
+    static struct csp_id_scope scope;
+    csp_id base = csp_id_start(&scope);
     check_id_ne(csp_id_add_name(base, "a"), csp_id_add_name(base, "b"));
     check_id_ne(csp_id_add_name(base, "a"), csp_id_add_name(base, "c"));
     check_id_ne(csp_id_add_name(base, "b"), csp_id_add_name(base, "c"));

--- a/tests/test-id-sets.c
+++ b/tests/test-id-sets.c
@@ -8,22 +8,23 @@
 #include "hst.h"
 #include "test-case-harness.h"
 
-#define CSP_ID_SET_FIRST_ALLOCATION_COUNT  32
+#define CSP_ID_SET_FIRST_ALLOCATION_COUNT 32
 
 TEST_CASE_GROUP("identifier sets");
 
 static void
 csp_id_set_builder_add_range(struct csp_id_set_builder *builder, size_t count)
 {
-    size_t  i;
+    size_t i;
     for (i = 0; i < count; i++) {
         csp_id_set_builder_add(builder, i);
     }
 }
 
-TEST_CASE("can create empty set") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can create empty set")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
     csp_id_set_build(&set, &builder);
@@ -32,9 +33,10 @@ TEST_CASE("can create empty set") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can add individual ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can add individual ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     check(csp_id_set_builder_add(&builder, 0));
     check(csp_id_set_builder_add(&builder, 5));
@@ -46,9 +48,10 @@ TEST_CASE("can add individual ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can add duplicate individual ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can add duplicate individual ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     check(csp_id_set_builder_add(&builder, 0));
     check(csp_id_set_builder_add(&builder, 5));
@@ -63,9 +66,10 @@ TEST_CASE("can add duplicate individual ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can remove individual ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can remove individual ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add(&builder, 0);
     csp_id_set_builder_add(&builder, 5);
@@ -79,9 +83,10 @@ TEST_CASE("can remove individual ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can remove missing individual ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can remove missing individual ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add(&builder, 0);
     csp_id_set_builder_add(&builder, 5);
@@ -95,11 +100,12 @@ TEST_CASE("can remove missing individual ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can add bulk ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
-    csp_id  to_add[] = {0, 5, 1};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+TEST_CASE("can add bulk ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
+    csp_id to_add[] = {0, 5, 1};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set);
@@ -109,11 +115,12 @@ TEST_CASE("can add bulk ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can add duplicate bulk ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
-    csp_id  to_add[] = {0, 5, 1, 5, 0, 0};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+TEST_CASE("can add duplicate bulk ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
+    csp_id to_add[] = {0, 5, 1, 5, 0, 0};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set);
@@ -123,13 +130,14 @@ TEST_CASE("can add duplicate bulk ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can remove bulk ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
-    csp_id  to_add[] = {0, 5, 1, 6};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
-    csp_id  to_remove[] = {1, 5};
-    size_t  to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
+TEST_CASE("can remove bulk ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
+    csp_id to_add[] = {0, 5, 1, 6};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+    csp_id to_remove[] = {1, 5};
+    size_t to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_builder_remove_many(&builder, to_remove_count, to_remove);
@@ -140,13 +148,14 @@ TEST_CASE("can remove bulk ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can remove missing bulk ids") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
-    csp_id  to_add[] = {0, 5, 1, 6};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
-    csp_id  to_remove[] = {1, 7};
-    size_t  to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
+TEST_CASE("can remove missing bulk ids")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
+    csp_id to_add[] = {0, 5, 1, 6};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+    csp_id to_remove[] = {1, 7};
+    size_t to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_builder_remove_many(&builder, to_remove_count, to_remove);
@@ -157,10 +166,11 @@ TEST_CASE("can remove missing bulk ids") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can merge sets") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set1;
-    struct csp_id_set  set2;
+TEST_CASE("can merge sets")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set1;
+    struct csp_id_set set2;
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add(&builder, 0);
     csp_id_set_builder_add(&builder, 1);
@@ -176,9 +186,10 @@ TEST_CASE("can merge sets") {
     csp_id_set_done(&set2);
 }
 
-TEST_CASE("can empty a builder when building a set") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can empty a builder when building a set")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add(&builder, 0);
     csp_id_set_builder_add(&builder, 5);
@@ -191,9 +202,10 @@ TEST_CASE("can empty a builder when building a set") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can keep a builder full when building a set") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can keep a builder full when building a set")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add(&builder, 0);
     csp_id_set_builder_add(&builder, 5);
@@ -206,12 +218,13 @@ TEST_CASE("can keep a builder full when building a set") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can clone a small set") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set1;
-    struct csp_id_set  set2;
-    csp_id  to_add[] = {0, 5, 1};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+TEST_CASE("can clone a small set")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set1;
+    struct csp_id_set set2;
+    csp_id to_add[] = {0, 5, 1};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     /* Create a set. */
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
@@ -228,14 +241,15 @@ TEST_CASE("can clone a small set") {
     csp_id_set_done(&set2);
 }
 
-TEST_CASE("can clone a large set") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set1;
-    struct csp_id_set  set2;
+TEST_CASE("can clone a large set")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set1;
+    struct csp_id_set set2;
     /* Create a set. */
     csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_range(
-            &builder, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
+    csp_id_set_builder_add_range(&builder,
+                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
     csp_id_set_init(&set1);
     csp_id_set_build(&set1, &builder);
     csp_id_set_builder_done(&builder);
@@ -249,13 +263,14 @@ TEST_CASE("can clone a large set") {
     csp_id_set_done(&set2);
 }
 
-TEST_CASE("can compare sets") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set1;
-    struct csp_id_set  set2;
-    struct csp_id_set  set3;
-    csp_id  to_add[] = {5, 1};
-    size_t  to_add_count = sizeof(to_add) / sizeof(to_add[0]);
+TEST_CASE("can compare sets")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set1;
+    struct csp_id_set set2;
+    struct csp_id_set set3;
+    csp_id to_add[] = {5, 1};
+    size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     /* bulk */
     csp_id_set_builder_init(&builder);
     csp_id_set_builder_add_many(&builder, to_add_count, to_add);
@@ -282,41 +297,46 @@ TEST_CASE("can compare sets") {
     csp_id_set_done(&set3);
 }
 
-TEST_CASE("can build a singleton set via shortcut") {
-    struct csp_id_set  set;
+TEST_CASE("can build a singleton set via shortcut")
+{
+    struct csp_id_set set;
     csp_id_set_init(&set);
     csp_id_set_fill_single(&set, 0);
     check_set_eq(&set, id_set(0));
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can build a doubleton set via shortcut") {
-    struct csp_id_set  set;
+TEST_CASE("can build a doubleton set via shortcut")
+{
+    struct csp_id_set set;
     csp_id_set_init(&set);
     csp_id_set_fill_double(&set, 0, 1);
     check_set_eq(&set, id_set(0, 1));
     csp_id_set_done(&set);
 }
 
-TEST_CASE("doubleton shortcut builder sorts events") {
-    struct csp_id_set  set;
+TEST_CASE("doubleton shortcut builder sorts events")
+{
+    struct csp_id_set set;
     csp_id_set_init(&set);
     csp_id_set_fill_double(&set, 1, 0);
     check_set_eq(&set, id_set(0, 1));
     csp_id_set_done(&set);
 }
 
-TEST_CASE("doubleton shortcut builder deduplicates events") {
-    struct csp_id_set  set;
+TEST_CASE("doubleton shortcut builder deduplicates events")
+{
+    struct csp_id_set set;
     csp_id_set_init(&set);
     csp_id_set_fill_double(&set, 0, 0);
     check_set_eq(&set, id_set(0));
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can spill over into allocated storage") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can spill over into allocated storage")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     /* Fill the set with too many elements to fit into the preallocated internal
      * storage, but few enough to fit into the default-sized heap-allocated
@@ -330,15 +350,16 @@ TEST_CASE("can spill over into allocated storage") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can spill over into large allocated storage") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can spill over into large allocated storage")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     /* Fill the set with too many elements to fit into the preallocated internal
      * storage, and too many too fit into the default-sized heap-allocated
      * buffer. */
-    csp_id_set_builder_add_range(
-            &builder, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
+    csp_id_set_builder_add_range(&builder,
+                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
     csp_id_set_init(&set);
     csp_id_set_build(&set, &builder);
     csp_id_set_builder_done(&builder);
@@ -347,9 +368,10 @@ TEST_CASE("can spill over into large allocated storage") {
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can reallocate allocated storage") {
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  set;
+TEST_CASE("can reallocate allocated storage")
+{
+    struct csp_id_set_builder builder;
+    struct csp_id_set set;
     csp_id_set_builder_init(&builder);
     /* Fill the set with one too many elements to fit into the preallocated
      * internal storage, causing an initial allocation. */
@@ -358,8 +380,8 @@ TEST_CASE("can reallocate allocated storage") {
     csp_id_set_build(&set, &builder);
     /* Then fill the set some more, to cause us to reallocate the heap-allocated
      * storage. */
-    csp_id_set_builder_add_range(
-            &builder, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
+    csp_id_set_builder_add_range(&builder,
+                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
     csp_id_set_build(&set, &builder);
     csp_id_set_builder_done(&builder);
     /* Verify that we got a valid set. */

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -8,8 +8,8 @@
 #include <string.h>
 
 #include "hst.h"
-#include "test-cases.h"
 #include "test-case-harness.h"
+#include "test-cases.h"
 
 /* The test cases in this file verify that we've implemented each of the CSP
  * operators correctly: specifically, that they have the right "initials" and
@@ -25,10 +25,10 @@ static void
 check_process_initials(struct csp_id_factory process,
                        struct csp_id_set_factory expected_initials)
 {
-    struct csp  *csp;
-    csp_id  process_id;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  actual;
+    struct csp *csp;
+    csp_id process_id;
+    struct csp_id_set_builder builder;
+    struct csp_id_set actual;
     check_alloc(csp, csp_new());
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
@@ -47,11 +47,11 @@ check_process_afters(struct csp_id_factory process,
                      struct csp_id_factory initial,
                      struct csp_id_set_factory expected_afters)
 {
-    struct csp  *csp;
-    csp_id  process_id;
-    csp_id  initial_id;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  actual;
+    struct csp *csp;
+    csp_id process_id;
+    csp_id initial_id;
+    struct csp_id_set_builder builder;
+    struct csp_id_set actual;
     check_alloc(csp, csp_new());
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
@@ -72,11 +72,11 @@ check_process_sub_initials(struct csp_id_factory process,
                            struct csp_id_factory subprocess,
                            struct csp_id_set_factory expected_initials)
 {
-    struct csp  *csp;
-    UNNEEDED csp_id  process_id;
-    csp_id  subprocess_id;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  actual;
+    struct csp *csp;
+    UNNEEDED csp_id process_id;
+    csp_id subprocess_id;
+    struct csp_id_set_builder builder;
+    struct csp_id_set actual;
     check_alloc(csp, csp_new());
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
@@ -98,12 +98,12 @@ check_process_sub_afters(struct csp_id_factory process,
                          struct csp_id_factory initial,
                          struct csp_id_set_factory expected_afters)
 {
-    struct csp  *csp;
-    UNNEEDED csp_id  process_id;
-    csp_id  subprocess_id;
-    csp_id  initial_id;
-    struct csp_id_set_builder  builder;
-    struct csp_id_set  actual;
+    struct csp *csp;
+    UNNEEDED csp_id process_id;
+    csp_id subprocess_id;
+    csp_id initial_id;
+    struct csp_id_set_builder builder;
+    struct csp_id_set actual;
     check_alloc(csp, csp_new());
     csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
@@ -120,76 +120,86 @@ check_process_sub_afters(struct csp_id_factory process,
 
 TEST_CASE_GROUP("external choice");
 
-TEST_CASE("STOP □ STOP") {
+TEST_CASE("STOP □ STOP")
+{
     check_process_initials(csp0("STOP □ STOP"), events());
     check_process_afters(csp0("STOP □ STOP"), event("a"), csp0s());
 }
 
-TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)") {
-    check_process_initials(
-            csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), events("a", "τ"));
-    check_process_afters(
-            csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("a"), csp0s("STOP"));
-    check_process_afters(
-            csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("b"), csp0s());
-    check_process_afters(
-            csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("τ"),
-            csp0s("a → STOP □ b → STOP", "a → STOP □ c → STOP"));
+TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)")
+{
+    check_process_initials(csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"),
+                           events("a", "τ"));
+    check_process_afters(csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("a"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("b"),
+                         csp0s());
+    check_process_afters(csp0("(a → STOP) □ (b → STOP ⊓ c → STOP)"), event("τ"),
+                         csp0s("a → STOP □ b → STOP", "a → STOP □ c → STOP"));
 }
 
-TEST_CASE("(a → STOP) □ (b → STOP)") {
+TEST_CASE("(a → STOP) □ (b → STOP)")
+{
     check_process_initials(csp0("(a → STOP) □ (b → STOP)"), events("a", "b"));
-    check_process_afters(csp0("(a → STOP) □ (b → STOP)"), event("a"), csp0s("STOP"));
-    check_process_afters(csp0("(a → STOP) □ (b → STOP)"), event("b"), csp0s("STOP"));
+    check_process_afters(csp0("(a → STOP) □ (b → STOP)"), event("a"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("(a → STOP) □ (b → STOP)"), event("b"),
+                         csp0s("STOP"));
     check_process_afters(csp0("(a → STOP) □ (b → STOP)"), event("τ"), csp0s());
 }
 
-TEST_CASE("□ {a → STOP, b → STOP, c → STOP}") {
-    check_process_initials(
-            csp0("□ {a → STOP, b → STOP, c → STOP}"), events("a", "b", "c"));
-    check_process_afters(
-            csp0("□ {a → STOP, b → STOP, c → STOP}"), event("a"), csp0s("STOP"));
-    check_process_afters(
-            csp0("□ {a → STOP, b → STOP, c → STOP}"), event("b"), csp0s("STOP"));
-    check_process_afters(
-            csp0("□ {a → STOP, b → STOP, c → STOP}"), event("c"), csp0s("STOP"));
-    check_process_afters(
-            csp0("□ {a → STOP, b → STOP, c → STOP}"), event("τ"), csp0s());
+TEST_CASE("□ {a → STOP, b → STOP, c → STOP}")
+{
+    check_process_initials(csp0("□ {a → STOP, b → STOP, c → STOP}"),
+                           events("a", "b", "c"));
+    check_process_afters(csp0("□ {a → STOP, b → STOP, c → STOP}"), event("a"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("□ {a → STOP, b → STOP, c → STOP}"), event("b"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("□ {a → STOP, b → STOP, c → STOP}"), event("c"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("□ {a → STOP, b → STOP, c → STOP}"), event("τ"),
+                         csp0s());
 }
 
 TEST_CASE_GROUP("internal choice");
 
-TEST_CASE("STOP ⊓ STOP") {
+TEST_CASE("STOP ⊓ STOP")
+{
     check_process_initials(csp0("STOP ⊓ STOP"), events("τ"));
     check_process_afters(csp0("STOP ⊓ STOP"), event("τ"), csp0s("STOP"));
     check_process_afters(csp0("STOP ⊓ STOP"), event("a"), csp0s());
 }
 
-TEST_CASE("(a → STOP) ⊓ (b → STOP)") {
+TEST_CASE("(a → STOP) ⊓ (b → STOP)")
+{
     check_process_initials(csp0("(a → STOP) ⊓ (b → STOP)"), events("τ"));
-    check_process_afters(
-            csp0("(a → STOP) ⊓ (b → STOP)"), event("τ"), csp0s("a → STOP", "b → STOP"));
+    check_process_afters(csp0("(a → STOP) ⊓ (b → STOP)"), event("τ"),
+                         csp0s("a → STOP", "b → STOP"));
     check_process_afters(csp0("(a → STOP) ⊓ (b → STOP)"), event("a"), csp0s());
 }
 
-TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}") {
-    check_process_initials(csp0("⊓ {a → STOP, b → STOP, c → STOP}"), events("τ"));
-    check_process_afters(
-            csp0("⊓ {a → STOP, b → STOP, c → STOP}"), event("τ"),
-            csp0s("a → STOP", "b → STOP", "c → STOP"));
-    check_process_afters(
-            csp0("⊓ {a → STOP, b → STOP, c → STOP}"), event("a"), csp0s());
+TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}")
+{
+    check_process_initials(csp0("⊓ {a → STOP, b → STOP, c → STOP}"),
+                           events("τ"));
+    check_process_afters(csp0("⊓ {a → STOP, b → STOP, c → STOP}"), event("τ"),
+                         csp0s("a → STOP", "b → STOP", "c → STOP"));
+    check_process_afters(csp0("⊓ {a → STOP, b → STOP, c → STOP}"), event("a"),
+                         csp0s());
 }
 
 TEST_CASE_GROUP("prefix");
 
-TEST_CASE("a → STOP") {
+TEST_CASE("a → STOP")
+{
     check_process_initials(csp0("a → STOP"), events("a"));
     check_process_afters(csp0("a → STOP"), event("a"), csp0s("STOP"));
     check_process_afters(csp0("a → STOP"), event("b"), csp0s());
 }
 
-TEST_CASE("a → b → STOP") {
+TEST_CASE("a → b → STOP")
+{
     check_process_initials(csp0("a → b → STOP"), events("a"));
     check_process_afters(csp0("a → b → STOP"), event("a"), csp0s("b → STOP"));
     check_process_afters(csp0("a → b → STOP"), event("b"), csp0s());
@@ -197,24 +207,28 @@ TEST_CASE("a → b → STOP") {
 
 TEST_CASE_GROUP("recursion");
 
-TEST_CASE("let X=a → STOP within X") {
+TEST_CASE("let X=a → STOP within X")
+{
     check_process_initials(csp0("let X=a → STOP within X"), events("a"));
-    check_process_afters(csp0("let X=a → STOP within X"), event("a"), csp0s("STOP"));
+    check_process_afters(csp0("let X=a → STOP within X"), event("a"),
+                         csp0s("STOP"));
 }
 
-TEST_CASE("let X=a → Y Y=b → X within X") {
+TEST_CASE("let X=a → Y Y=b → X within X")
+{
     check_process_initials(csp0("let X=a → Y Y=b → X within X"), events("a"));
-    check_process_afters(
-            csp0("let X=a → Y Y=b → X within X"), event("a"), csp0s("Y@0"));
-    check_process_sub_initials(
-            csp0("let X=a → Y Y=b → X within X"), csp0("Y@0"), events("b"));
-    check_process_sub_afters(
-            csp0("let X=a → Y Y=b → X within X"), csp0("Y@0"), event("b"), csp0s("X@0"));
+    check_process_afters(csp0("let X=a → Y Y=b → X within X"), event("a"),
+                         csp0s("Y@0"));
+    check_process_sub_initials(csp0("let X=a → Y Y=b → X within X"),
+                               csp0("Y@0"), events("b"));
+    check_process_sub_afters(csp0("let X=a → Y Y=b → X within X"), csp0("Y@0"),
+                             event("b"), csp0s("X@0"));
 }
 
 TEST_CASE_GROUP("sequential composition");
 
-TEST_CASE("SKIP ; STOP") {
+TEST_CASE("SKIP ; STOP")
+{
     check_process_initials(csp0("SKIP ; STOP"), events("τ"));
     check_process_afters(csp0("SKIP ; STOP"), event("a"), csp0s());
     check_process_afters(csp0("SKIP ; STOP"), event("b"), csp0s());
@@ -222,31 +236,39 @@ TEST_CASE("SKIP ; STOP") {
     check_process_afters(csp0("SKIP ; STOP"), event("✔"), csp0s());
 }
 
-TEST_CASE("a → SKIP ; STOP") {
+TEST_CASE("a → SKIP ; STOP")
+{
     check_process_initials(csp0("a → SKIP ; STOP"), events("a"));
-    check_process_afters(csp0("a → SKIP ; STOP"), event("a"), csp0s("SKIP ; STOP"));
+    check_process_afters(csp0("a → SKIP ; STOP"), event("a"),
+                         csp0s("SKIP ; STOP"));
     check_process_afters(csp0("a → SKIP ; STOP"), event("b"), csp0s());
     check_process_afters(csp0("a → SKIP ; STOP"), event("τ"), csp0s());
     check_process_afters(csp0("a → SKIP ; STOP"), event("✔"), csp0s());
 }
 
-TEST_CASE("(a → b → STOP □ SKIP) ; STOP") {
-    check_process_initials(csp0("(a → b → STOP □ SKIP) ; STOP"), events("a", "τ"));
-    check_process_afters(
-            csp0("(a → b → STOP □ SKIP) ; STOP"), event("a"),
-            csp0s("b → STOP ; STOP"));
-    check_process_afters(
-            csp0("(a → b → STOP □ SKIP) ; STOP"), event("b"), csp0s());
-    check_process_afters(
-            csp0("(a → b → STOP □ SKIP) ; STOP"), event("τ"), csp0s("STOP"));
-    check_process_afters(csp0("(a → b → STOP □ SKIP) ; STOP"), event("✔"), csp0s());
+TEST_CASE("(a → b → STOP □ SKIP) ; STOP")
+{
+    check_process_initials(csp0("(a → b → STOP □ SKIP) ; STOP"),
+                           events("a", "τ"));
+    check_process_afters(csp0("(a → b → STOP □ SKIP) ; STOP"), event("a"),
+                         csp0s("b → STOP ; STOP"));
+    check_process_afters(csp0("(a → b → STOP □ SKIP) ; STOP"), event("b"),
+                         csp0s());
+    check_process_afters(csp0("(a → b → STOP □ SKIP) ; STOP"), event("τ"),
+                         csp0s("STOP"));
+    check_process_afters(csp0("(a → b → STOP □ SKIP) ; STOP"), event("✔"),
+                         csp0s());
 }
 
-TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP") {
+TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP")
+{
     check_process_initials(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), events("τ"));
-    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("a"), csp0s());
-    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("b"), csp0s());
+    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("a"),
+                         csp0s());
+    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("b"),
+                         csp0s());
     check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("τ"),
-                      csp0s("a → b → STOP ; STOP", "SKIP ; STOP"));
-    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("✔"), csp0s());
+                         csp0s("a → b → STOP ; STOP", "SKIP ; STOP"));
+    check_process_afters(csp0("(a → b → STOP ⊓ SKIP) ; STOP"), event("✔"),
+                         csp0s());
 }

--- a/tests/test-refinement.c
+++ b/tests/test-refinement.c
@@ -8,8 +8,8 @@
 #include <string.h>
 
 #include "hst.h"
-#include "test-cases.h"
 #include "test-case-harness.h"
+#include "test-cases.h"
 
 /* The test cases in this file verify that we've implemented refinement
  * correctly. */
@@ -22,31 +22,32 @@ static void
 add_normalized_node(struct csp *csp, struct csp_normalized_lts *lts, csp_id *id,
                     struct csp_id_set_factory processes)
 {
-    const struct csp_id_set  *process_ids =
-        csp_id_set_factory_create(csp, processes);
+    const struct csp_id_set *process_ids =
+            csp_id_set_factory_create(csp, processes);
     check(csp_normalized_lts_add_node(lts, process_ids, id));
 }
 
 static void
-check_normalized_node(struct csp *csp, struct csp_normalized_lts *lts, csp_id id,
-                      struct csp_id_set_factory processes)
+check_normalized_node(struct csp *csp, struct csp_normalized_lts *lts,
+                      csp_id id, struct csp_id_set_factory processes)
 {
-    const struct csp_id_set  *actual =
-        csp_normalized_lts_get_node_processes(lts, id);
-    const struct csp_id_set  *process_ids =
-        csp_id_set_factory_create(csp, processes);
+    const struct csp_id_set *actual =
+            csp_normalized_lts_get_node_processes(lts, id);
+    const struct csp_id_set *process_ids =
+            csp_id_set_factory_create(csp, processes);
     check_set_eq(actual, process_ids);
 }
 
 TEST_CASE_GROUP("normalized LTSes");
 
-TEST_CASE("can build normalized LTS") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
-    csp_id  id1;
-    csp_id  id2;
-    csp_id  id3;
-    csp_id  id4;
+TEST_CASE("can build normalized LTS")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
+    csp_id id1;
+    csp_id id2;
+    csp_id id3;
+    csp_id id4;
     /* Create the CSP environment and LTS. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
@@ -69,17 +70,18 @@ static void
 add_duplicate_normalized_node(struct csp *csp, struct csp_normalized_lts *lts,
                               csp_id id, struct csp_id_set_factory processes)
 {
-    const struct csp_id_set  *process_ids =
-        csp_id_set_factory_create(csp, processes);
-    csp_id  new_id;
+    const struct csp_id_set *process_ids =
+            csp_id_set_factory_create(csp, processes);
+    csp_id new_id;
     check(!csp_normalized_lts_add_node(lts, process_ids, &new_id));
     check_id_eq(new_id, id);
 }
 
-TEST_CASE("can detect duplicate normalized LTS nodes") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
-    csp_id  id;
+TEST_CASE("can detect duplicate normalized LTS nodes")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
+    csp_id id;
     /* Create the CSP environment and LTS. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
@@ -89,10 +91,10 @@ TEST_CASE("can detect duplicate normalized LTS nodes") {
     add_duplicate_normalized_node(csp, lts, id, csp0s("STOP"));
     /* For sets of processes, the order shouldn't matter. */
     add_normalized_node(csp, lts, &id, csp0s("a → STOP", "b → c → STOP"));
-    add_duplicate_normalized_node(
-            csp, lts, id, csp0s("a → STOP", "b → c → STOP"));
-    add_duplicate_normalized_node(
-            csp, lts, id, csp0s("b → c → STOP", "a → STOP"));
+    add_duplicate_normalized_node(csp, lts, id,
+                                  csp0s("a → STOP", "b → c → STOP"));
+    add_duplicate_normalized_node(csp, lts, id,
+                                  csp0s("b → c → STOP", "a → STOP"));
     /* Clean up. */
     csp_normalized_lts_free(lts);
     csp_free(csp);
@@ -102,17 +104,18 @@ static void
 check_normalized_edge_by_id(struct csp_normalized_lts *lts, csp_id from,
                             csp_id event, csp_id expected)
 {
-    csp_id  actual = csp_normalized_lts_get_edge(lts, from, event);
+    csp_id actual = csp_normalized_lts_get_edge(lts, from, event);
     check_id_eq(actual, expected);
 }
 
-TEST_CASE("can add edges to normalized LTS") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
-    csp_id  id1;
-    csp_id  id2;
-    csp_id  id3;
-    csp_id  id4;
+TEST_CASE("can add edges to normalized LTS")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
+    csp_id id1;
+    csp_id id2;
+    csp_id id3;
+    csp_id id4;
     /* Create the CSP environment and LTS. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
@@ -147,10 +150,10 @@ static void
 check_closure(struct csp *csp, struct csp_id_factory process,
               struct csp_id_factory event, struct csp_id_set_factory expected)
 {
-    csp_id  process_id;
-    csp_id  event_id;
-    const struct csp_id_set  *expected_set;
-    struct csp_id_set  actual;
+    csp_id process_id;
+    csp_id event_id;
+    const struct csp_id_set *expected_set;
+    struct csp_id_set actual;
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     event_id = csp_id_factory_create(csp, event);
@@ -163,24 +166,26 @@ check_closure(struct csp *csp, struct csp_id_factory process,
 
 TEST_CASE_GROUP("closures");
 
-TEST_CASE("a → a → a → STOP □ a → b → STOP") {
-    struct csp  *csp;
+TEST_CASE("a → a → a → STOP □ a → b → STOP")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* a → STOP □ b → STOP */
     check_closure(csp, csp0("a → a → a → STOP □ a → b → STOP"), event("τ"),
                   csp0s("a → a → a → STOP □ a → b → STOP"));
     check_closure(csp, csp0("a → a → a → STOP □ a → b → STOP"), event("a"),
-                  csp0s("a → a → a → STOP □ a → b → STOP",
-                        "a → a → STOP", "a → STOP", "STOP", "b → STOP"));
+                  csp0s("a → a → a → STOP □ a → b → STOP", "a → a → STOP",
+                        "a → STOP", "STOP", "b → STOP"));
     check_closure(csp, csp0("a → a → a → STOP □ a → b → STOP"), event("b"),
                   csp0s("a → a → a → STOP □ a → b → STOP"));
     /* Clean up. */
     csp_free(csp);
 }
 
-TEST_CASE("a → STOP □ b → STOP") {
-    struct csp  *csp;
+TEST_CASE("a → STOP □ b → STOP")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* a → STOP □ b → STOP */
@@ -194,15 +199,16 @@ TEST_CASE("a → STOP □ b → STOP") {
     csp_free(csp);
 }
 
-TEST_CASE("a → STOP ⊓ (b → STOP ⊓ c → STOP)") {
-    struct csp  *csp;
+TEST_CASE("a → STOP ⊓ (b → STOP ⊓ c → STOP)")
+{
+    struct csp *csp;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     /* a → STOP □ b → STOP */
-    check_closure(csp, csp0("a → STOP ⊓ (b → STOP ⊓ c → STOP)"), event("τ"),
-                  csp0s("a → STOP ⊓ (b → STOP ⊓ c → STOP)",
-                        "b → STOP ⊓ c → STOP",
-                        "a → STOP", "b → STOP", "c → STOP"));
+    check_closure(
+            csp, csp0("a → STOP ⊓ (b → STOP ⊓ c → STOP)"), event("τ"),
+            csp0s("a → STOP ⊓ (b → STOP ⊓ c → STOP)", "b → STOP ⊓ c → STOP",
+                  "a → STOP", "b → STOP", "c → STOP"));
     check_closure(csp, csp0("a → STOP ⊓ (b → STOP ⊓ c → STOP)"), event("a"),
                   csp0s("a → STOP ⊓ (b → STOP ⊓ c → STOP)"));
     check_closure(csp, csp0("a → STOP ⊓ (b → STOP ⊓ c → STOP)"), event("b"),
@@ -222,10 +228,10 @@ check_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
                    struct csp_id_factory process,
                    struct csp_id_set_factory expected_closure)
 {
-    csp_id  process_id;
-    csp_id  normalized_node;
-    const struct csp_id_set  *processes;
-    const struct csp_id_set  *expected_closure_set;
+    csp_id process_id;
+    csp_id normalized_node;
+    const struct csp_id_set *processes;
+    const struct csp_id_set *expected_closure_set;
     process_id = csp_id_factory_create(csp, process);
     expected_closure_set = csp_id_set_factory_create(csp, expected_closure);
     normalized_node = csp_process_prenormalize(csp, lts, process_id);
@@ -239,12 +245,12 @@ check_normalized_edge(struct csp *csp, struct csp_normalized_lts *lts,
                       struct csp_id_factory event,
                       struct csp_id_set_factory to_node)
 {
-    const struct csp_id_set  *from_node_set;
-    const struct csp_id_set  *to_node_set;
-    csp_id  event_id;
-    csp_id  from_node_id;
-    csp_id  actual;
-    csp_id  expected;
+    const struct csp_id_set *from_node_set;
+    const struct csp_id_set *to_node_set;
+    csp_id event_id;
+    csp_id from_node_id;
+    csp_id actual;
+    csp_id expected;
     from_node_set = csp_id_set_factory_create(csp, from_node);
     event_id = csp_id_factory_create(csp, event);
     to_node_set = csp_id_set_factory_create(csp, to_node);
@@ -254,74 +260,76 @@ check_normalized_edge(struct csp *csp, struct csp_normalized_lts *lts,
     check_id_eq(actual, expected);
 }
 
-TEST_CASE("a → STOP") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
+TEST_CASE("a → STOP")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
     /* Prenormalize the process and verify we get all of the edges we expect. */
     check_prenormalize(csp, lts, csp0("a → STOP"), csp0s("a → STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → STOP"), event("a"), csp0s("STOP"));
+    check_normalized_edge(csp, lts, csp0s("a → STOP"), event("a"),
+                          csp0s("STOP"));
     /* Clean up. */
     csp_normalized_lts_free(lts);
     csp_free(csp);
 }
 
-TEST_CASE("a → STOP □ b → STOP") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
+TEST_CASE("a → STOP □ b → STOP")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
     /* Prenormalize the process and verify we get all of the edges we expect. */
     check_prenormalize(csp, lts, csp0("a → STOP □ b → STOP"),
                        csp0s("a → STOP □ b → STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → STOP □ b → STOP"), event("a"), csp0s("STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → STOP □ b → STOP"), event("b"), csp0s("STOP"));
+    check_normalized_edge(csp, lts, csp0s("a → STOP □ b → STOP"), event("a"),
+                          csp0s("STOP"));
+    check_normalized_edge(csp, lts, csp0s("a → STOP □ b → STOP"), event("b"),
+                          csp0s("STOP"));
     /* Clean up. */
     csp_normalized_lts_free(lts);
     csp_free(csp);
 }
 
-TEST_CASE("a → STOP ⊓ b → STOP") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
+TEST_CASE("a → STOP ⊓ b → STOP")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
     /* Prenormalize the process and verify we get all of the edges we expect. */
     check_prenormalize(csp, lts, csp0("a → STOP ⊓ b → STOP"),
                        csp0s("a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"),
-            event("a"), csp0s("STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"),
-            event("b"), csp0s("STOP"));
+    check_normalized_edge(csp, lts,
+                          csp0s("a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"),
+                          event("a"), csp0s("STOP"));
+    check_normalized_edge(csp, lts,
+                          csp0s("a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"),
+                          event("b"), csp0s("STOP"));
     /* Clean up. */
     csp_normalized_lts_free(lts);
     csp_free(csp);
 }
 
-TEST_CASE("a → SKIP ; b → STOP") {
-    struct csp  *csp;
-    struct csp_normalized_lts  *lts;
+TEST_CASE("a → SKIP ; b → STOP")
+{
+    struct csp *csp;
+    struct csp_normalized_lts *lts;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     check_alloc(lts, csp_normalized_lts_new(csp));
     /* Prenormalize the process and verify we get all of the edges we expect. */
     check_prenormalize(csp, lts, csp0("a → SKIP ; b → STOP"),
                        csp0s("a → SKIP ; b → STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("a → SKIP ; b → STOP"), event("a"),
-            csp0s("SKIP ; b → STOP", "b → STOP"));
-    check_normalized_edge(
-            csp, lts, csp0s("SKIP ; b → STOP", "b → STOP"), event("b"),
-            csp0s("STOP"));
+    check_normalized_edge(csp, lts, csp0s("a → SKIP ; b → STOP"), event("a"),
+                          csp0s("SKIP ; b → STOP", "b → STOP"));
+    check_normalized_edge(csp, lts, csp0s("SKIP ; b → STOP", "b → STOP"),
+                          event("b"), csp0s("STOP"));
     /* Clean up. */
     csp_normalized_lts_free(lts);
     csp_free(csp);


### PR DESCRIPTION
Let's bite the bullet now!  The new .clang-format file is the canonical description of our coding style.  Moving forward, be sure to always run `git clang-format` (or run `clang-format -i` on a file directly) to ensure that each file is formatted correctly.