### PR TITLE
Remove set builders

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,8 @@ ContinuationIndentWidth: 8
 DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-#ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros:
+  - csp_id_set_foreach
 IncludeCategories:
   - Regex:    '^<.*\.h>'
     Priority: 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,14 +31,17 @@ dist-hook:
 	@rm -rf `find $(top_distdir)/third_party -type d -name .libs`
 
 libhst_la_SOURCES = \
-	src/hst.h \
+	src/basics.h \
 	src/behavior.c \
 	src/csp0.c \
 	src/denotational.c \
 	src/environment.c \
 	src/equivalence.c \
+	src/hst.h \
 	src/id-pair.c \
+	src/id-set.h \
 	src/id-set.c \
+	src/macros.h \
 	src/normalized-lts.c \
 	src/refinement.c \
 	src/operators/external-choice.c \

--- a/src/basics.h
+++ b/src/basics.h
@@ -1,0 +1,19 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_BASICS_H
+#define HST_BASICS_H
+
+#include <inttypes.h>
+#include <stdint.h>
+
+/* Each process and event is identified by a number. */
+typedef uint64_t csp_id;
+#define CSP_ID_FMT "0x%016" PRIx64
+#define CSP_ID_NONE ((csp_id) 0)
+
+#endif /* HST_BASICS_H */

--- a/src/behavior.c
+++ b/src/behavior.c
@@ -46,19 +46,16 @@ csp_behavior_refines(const struct csp_behavior *spec,
 
 static void
 csp_process_add_traces_behavior(struct csp *csp, csp_id process,
-                                struct csp_behavior *behavior,
-                                struct csp_id_set_builder *builder)
+                                struct csp_behavior *behavior)
 {
-    csp_process_build_initials(csp, process, builder);
+    csp_process_build_initials(csp, process, &behavior->initials);
 }
 
 static void
-csp_behavior_finish_traces(struct csp *csp, struct csp_behavior *behavior,
-                           struct csp_id_set_builder *builder)
+csp_behavior_finish_traces(struct csp *csp, struct csp_behavior *behavior)
 {
     behavior->model = CSP_TRACES;
-    csp_id_set_builder_remove(builder, csp->tau);
-    csp_id_set_build(&behavior->initials, builder);
+    csp_id_set_remove(&behavior->initials, csp->tau);
     behavior->hash = behavior->initials.hash;
 }
 
@@ -66,11 +63,9 @@ static void
 csp_process_get_traces_behavior(struct csp *csp, csp_id process,
                                 struct csp_behavior *behavior)
 {
-    struct csp_id_set_builder builder;
-    csp_id_set_builder_init(&builder);
-    csp_process_add_traces_behavior(csp, process, behavior, &builder);
-    csp_behavior_finish_traces(csp, behavior, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_clear(&behavior->initials);
+    csp_process_add_traces_behavior(csp, process, behavior);
+    csp_behavior_finish_traces(csp, behavior);
 }
 
 void
@@ -92,15 +87,12 @@ csp_process_set_get_traces_behavior(struct csp *csp,
                                     const struct csp_id_set *processes,
                                     struct csp_behavior *behavior)
 {
-    size_t i;
-    struct csp_id_set_builder builder;
-    csp_id_set_builder_init(&builder);
-    for (i = 0; i < processes->count; i++) {
-        csp_process_add_traces_behavior(csp, processes->ids[i], behavior,
-                                        &builder);
+    struct csp_id_set_iterator iter;
+    csp_id_set_clear(&behavior->initials);
+    csp_id_set_foreach (processes, &iter) {
+        csp_process_add_traces_behavior(csp, iter.current, behavior);
     }
-    csp_behavior_finish_traces(csp, behavior, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_behavior_finish_traces(csp, behavior);
 }
 
 void

--- a/src/csp0.c
+++ b/src/csp0.c
@@ -191,31 +191,25 @@ parse_process(struct csp0_parse_state *state, csp_id *dest);
 static int
 parse_process_set(struct csp0_parse_state *state, struct csp_id_set *set)
 {
-    struct csp_id_set_builder builder;
     csp_id process;
     DEBUG("ENTER  process set");
 
-    csp_id_set_builder_init(&builder);
     require(parse_token(state, "{"));
     skip_whitespace(state);
     if (parse_process(state, &process) == 0) {
-        csp_id_set_builder_add(&builder, process);
+        csp_id_set_add(set, process);
         skip_whitespace(state);
         while (parse_token(state, ",") == 0) {
             skip_whitespace(state);
             if (unlikely(parse_process(state, &process) != 0)) {
                 // Expected process after `,`
-                csp_id_set_build(set, &builder);
-                csp_id_set_builder_done(&builder);
                 DEBUG("FAIL   process set");
                 return -1;
             }
-            csp_id_set_builder_add(&builder, process);
+            csp_id_set_add(set, process);
             skip_whitespace(state);
         }
     }
-    csp_id_set_build(set, &builder);
-    csp_id_set_builder_done(&builder);
     if (unlikely(parse_token(state, "}") != 0)) {
         // Expected process `}`
         DEBUG("FAIL   process set");

--- a/src/equivalence.c
+++ b/src/equivalence.c
@@ -78,13 +78,13 @@ csp_equivalences_add(struct csp_equivalences *equiv, csp_id class_id,
 
 void
 csp_equivalences_build_classes(struct csp_equivalences *equiv,
-                               struct csp_id_set_builder *builder)
+                               struct csp_id_set *set)
 {
     Word_t *vmembers;
     csp_id class_id = 0;
     JLF(vmembers, equiv->classes, class_id);
     while (vmembers != NULL) {
-        csp_id_set_builder_add(builder, class_id);
+        csp_id_set_add(set, class_id);
         JLN(vmembers, equiv->classes, class_id);
     }
 }
@@ -103,7 +103,7 @@ csp_equivalences_get_class(struct csp_equivalences *equiv, csp_id member_id)
 
 void
 csp_equivalences_build_members(struct csp_equivalences *equiv, csp_id class_id,
-                               struct csp_id_set_builder *builder)
+                               struct csp_id_set *set)
 {
     Word_t *vmembers;
     JLG(vmembers, equiv->classes, class_id);
@@ -113,7 +113,7 @@ csp_equivalences_build_members(struct csp_equivalences *equiv, csp_id class_id,
         csp_id member_id = 0;
         J1F(found, *members, member_id);
         while (found) {
-            csp_id_set_builder_add(builder, member_id);
+            csp_id_set_add(set, member_id);
             J1N(found, *members, member_id);
         }
     }

--- a/src/id-set.h
+++ b/src/id-set.h
@@ -1,0 +1,88 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_ID_SET_H
+#define HST_ID_SET_H
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "basics.h"
+
+struct csp_id_set {
+    csp_id hash;
+    size_t count;
+    void *elements;
+};
+
+void
+csp_id_set_init(struct csp_id_set *set);
+
+void
+csp_id_set_done(struct csp_id_set *set);
+
+bool
+csp_id_set_eq(const struct csp_id_set *set1, const struct csp_id_set *set2);
+
+/* Return whether set1 ⊆ set2 */
+bool
+csp_id_set_subseteq(const struct csp_id_set *set1,
+                    const struct csp_id_set *set2);
+
+void
+csp_id_set_clear(struct csp_id_set *set);
+
+/* Add a single ID to a set.  Return whether the ID is new (i.e., it wasn't
+ * already in `set`.) */
+bool
+csp_id_set_add(struct csp_id_set *set, csp_id id);
+
+/* Add several IDs to a set.  `ids` does not need to be sorted, and it's okay
+ * for it to contain duplicates.  Returns true if any of the elements were not
+ * already in the set. */
+bool
+csp_id_set_add_many(struct csp_id_set *set, size_t count, csp_id *ids);
+
+/* Remove a single ID from a set.  Returns whether that ID was in the set or
+ * not. */
+bool
+csp_id_set_remove(struct csp_id_set *set, csp_id id);
+
+/* Remove several IDs from a set.  `ids` does not need to be sorted, and it's
+ * okay for it to contain duplicates.  Returns true if any of elements were
+ * removed. */
+bool
+csp_id_set_remove_many(struct csp_id_set *set, size_t count, csp_id *ids);
+
+/* Add the contents of an existing set to a set.  Returns true if any new
+ * elements were added. */
+bool
+csp_id_set_union(struct csp_id_set *set, const struct csp_id_set *other);
+
+struct csp_id_set_iterator {
+    void *const *elements;
+    csp_id current;
+    int found;
+};
+
+void
+csp_id_set_iterate(const struct csp_id_set *set,
+                   struct csp_id_set_iterator *iter);
+
+bool
+csp_id_set_iterator_done(struct csp_id_set_iterator *iter);
+
+void
+csp_id_set_iterator_advance(struct csp_id_set_iterator *iter);
+
+#define csp_id_set_foreach(set, iter)                                          \
+    for (csp_id_set_iterate((set), (iter)); !csp_id_set_iterator_done((iter)); \
+         csp_id_set_iterator_advance((iter)))
+
+
+#endif /* HST_ID_SET_H */

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,0 +1,19 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_MACROS_H
+#define HST_MACROS_H
+
+#define swap(a, b)        \
+    do {                  \
+        typeof(a) __swap; \
+        __swap = (a);     \
+        (a) = (b);        \
+        (b) = __swap;     \
+    } while (0)
+
+#endif /* HST_MACROS_H */

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -22,21 +22,21 @@ struct csp_internal_choice {
  */
 
 static void
-csp_internal_choice_initials(struct csp *csp,
-                             struct csp_id_set_builder *builder, void *vchoice)
+csp_internal_choice_initials(struct csp *csp, struct csp_id_set *set,
+                             void *vchoice)
 {
     /* initials(⊓ Ps) = {τ} */
-    csp_id_set_builder_add(builder, csp->tau);
+    csp_id_set_add(set, csp->tau);
 }
 
 static void
 csp_internal_choice_afters(struct csp *csp, csp_id initial,
-                           struct csp_id_set_builder *builder, void *vchoice)
+                           struct csp_id_set *set, void *vchoice)
 {
     /* afters(⊓ Ps, τ) = Ps */
     struct csp_internal_choice *choice = vchoice;
     if (initial == csp->tau) {
-        csp_id_set_builder_merge(builder, &choice->ps);
+        csp_id_set_union(set, &choice->ps);
     }
 }
 
@@ -62,7 +62,7 @@ csp_internal_choice_init(struct csp *csp, void *vchoice, const void *vps)
     struct csp_internal_choice *choice = vchoice;
     const struct csp_id_set *ps = vps;
     csp_id_set_init(&choice->ps);
-    csp_id_set_clone(&choice->ps, ps);
+    csp_id_set_union(&choice->ps, ps);
 }
 
 static void
@@ -83,7 +83,8 @@ csp_internal_choice(struct csp *csp, csp_id a, csp_id b)
     csp_id id;
     struct csp_id_set ps;
     csp_id_set_init(&ps);
-    csp_id_set_fill_double(&ps, a, b);
+    csp_id_set_add(&ps, a);
+    csp_id_set_add(&ps, b);
     id = csp_process_init(csp, &ps, NULL, &csp_internal_choice_iface);
     csp_id_set_done(&ps);
     return id;

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -22,22 +22,21 @@ struct csp_prefix {
  */
 
 static void
-csp_prefix_initials(struct csp *csp, struct csp_id_set_builder *builder,
-                    void *vprefix)
+csp_prefix_initials(struct csp *csp, struct csp_id_set *set, void *vprefix)
 {
     /* initials(a → P) = {a} */
     struct csp_prefix *prefix = vprefix;
-    csp_id_set_builder_add(builder, prefix->a);
+    csp_id_set_add(set, prefix->a);
 }
 
 static void
-csp_prefix_afters(struct csp *csp, csp_id initial,
-                  struct csp_id_set_builder *builder, void *vprefix)
+csp_prefix_afters(struct csp *csp, csp_id initial, struct csp_id_set *set,
+                  void *vprefix)
 {
     /* afters(a → P, a) = P */
     struct csp_prefix *prefix = vprefix;
     if (initial == prefix->a) {
-        csp_id_set_builder_add(builder, prefix->p);
+        csp_id_set_add(set, prefix->p);
     }
 }
 

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -45,21 +45,21 @@ struct csp_recursion {
 };
 
 static void
-csp_recursion_initials(struct csp *csp, struct csp_id_set_builder *builder,
+csp_recursion_initials(struct csp *csp, struct csp_id_set *set,
                        void *vrecursion)
 {
     struct csp_recursion *recursion = vrecursion;
     assert(recursion->process != CSP_PROCESS_NONE);
-    csp_process_build_initials(csp, recursion->process, builder);
+    csp_process_build_initials(csp, recursion->process, set);
 }
 
 static void
-csp_recursion_afters(struct csp *csp, csp_id initial,
-                     struct csp_id_set_builder *builder, void *vrecursion)
+csp_recursion_afters(struct csp *csp, csp_id initial, struct csp_id_set *set,
+                     void *vrecursion)
 {
     struct csp_recursion *recursion = vrecursion;
     assert(recursion->process != CSP_PROCESS_NONE);
-    csp_process_build_afters(csp, recursion->process, initial, builder);
+    csp_process_build_afters(csp, recursion->process, initial, set);
 }
 
 static csp_id

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -6,6 +6,7 @@
  */
 
 #include "hst.h"
+#include "macros.h"
 
 #if defined(REFINEMENT_DEBUG)
 #include <stdio.h>
@@ -66,37 +67,32 @@ void
 csp_process_find_closure(struct csp *csp, csp_id event,
                          struct csp_id_set *processes)
 {
-    struct csp_id_set_builder queue;
-    struct csp_id_set_builder seen;
-    struct csp_id_set_builder result;
-    csp_id_set_builder_init(&queue);
-    csp_id_set_builder_init(&seen);
-    csp_id_set_builder_init(&result);
-
-    csp_id_set_builder_merge(&queue, processes);
-    csp_id_set_build(processes, &queue);
-    while (processes->count > 0) {
-        size_t i;
-        for (i = 0; i < processes->count; i++) {
-            csp_id process = processes->ids[i];
+    bool another_round_needed = true;
+    struct csp_id_set queue1;
+    struct csp_id_set queue2;
+    struct csp_id_set *current_queue = &queue1;
+    struct csp_id_set *next_queue = &queue2;
+    csp_id_set_init(&queue1);
+    csp_id_set_init(&queue2);
+    csp_id_set_union(current_queue, processes);
+    XDEBUG("=== closure of ");
+    DEBUG_PROCESS_SET(processes);
+    while (another_round_needed) {
+        struct csp_id_set_iterator i;
+        DEBUG("--- start closure iteration %p", current_queue);
+        csp_id_set_clear(next_queue);
+        csp_id_set_foreach (current_queue, &i) {
+            csp_id process = i.current;
             DEBUG("process " CSP_ID_FMT, process);
-            /* Don't handle this process more than once. */
-            if (csp_id_set_builder_add(&seen, process)) {
-                DEBUG("NEW     " CSP_ID_FMT, process);
-                /* Add this process to the final result. */
-                csp_id_set_builder_add(&result, process);
-                /* Enqueue each of the states that we can reach from `process`
-                 * by following a single `event`. */
-                csp_process_build_afters(csp, process, event, &queue);
-            }
+            /* Enqueue each of the states that we can reach from `process` by
+             * following a single `event`. */
+            csp_process_build_afters(csp, process, event, next_queue);
         }
-        csp_id_set_build(processes, &queue);
+        another_round_needed = csp_id_set_union(processes, next_queue);
+        swap(current_queue, next_queue);
     }
-
-    csp_id_set_build(processes, &result);
-    csp_id_set_builder_done(&queue);
-    csp_id_set_builder_done(&seen);
-    csp_id_set_builder_done(&result);
+    csp_id_set_done(&queue1);
+    csp_id_set_done(&queue2);
 }
 
 csp_id
@@ -105,20 +101,20 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
 {
     csp_id node;
     struct csp_id_set closure;
-    struct csp_id_set pending;
+    struct csp_id_set pending1;
+    struct csp_id_set pending2;
+    struct csp_id_set *current_pending = &pending1;
+    struct csp_id_set *next_pending = &pending2;
     struct csp_id_set initials;
-    struct csp_id_set_builder builder;
-    struct csp_id_set_builder pending_builder;
     csp_id_set_init(&closure);
-    csp_id_set_init(&pending);
+    csp_id_set_init(&pending1);
+    csp_id_set_init(&pending2);
     csp_id_set_init(&initials);
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_init(&pending_builder);
 
     DEBUG("Prenormalize " CSP_ID_FMT, process);
 
     /* First find the τ-closure of the initial process. */
-    csp_id_set_fill_single(&closure, process);
+    csp_id_set_add(&closure, process);
     csp_process_find_closure(csp, csp->tau, &closure);
     XDEBUG("τ closure is ");
     DEBUG_PROCESS_SET(&closure);
@@ -129,15 +125,16 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
               process);
         csp_normalized_lts_add_normalized_root(lts, process, node);
         DEBUG("Enqueue normalized node " CSP_ID_FMT, node);
-        csp_id_set_fill_single(&pending, node);
+        csp_id_set_add(current_pending, node);
     }
 
     /* Keep processing normalized LTS nodes until we run out. */
-    while (pending.count > 0) {
-        size_t i;
-        for (i = 0; i < pending.count; i++) {
-            size_t j;
-            csp_id current = pending.ids[i];
+    while (current_pending->count > 0) {
+        struct csp_id_set_iterator i;
+        csp_id_set_clear(next_pending);
+        csp_id_set_foreach (current_pending, &i) {
+            struct csp_id_set_iterator j;
+            csp_id current = i.current;
             const struct csp_id_set *current_processes =
                     csp_normalized_lts_get_node_processes(lts, current);
             DEBUG("Process normalized node " CSP_ID_FMT, current);
@@ -146,32 +143,31 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
 
             /* Find all of the non-τ events that any of the current processes
              * can perform. */
-            for (j = 0; j < current_processes->count; j++) {
-                csp_id process = current_processes->ids[j];
+            csp_id_set_clear(&initials);
+            csp_id_set_foreach (current_processes, &j) {
+                csp_id process = j.current;
                 DEBUG("Get initials of " CSP_ID_FMT, process);
-                csp_process_build_initials(csp, process, &builder);
+                csp_process_build_initials(csp, process, &initials);
             }
-            csp_id_set_builder_remove(&builder, csp->tau);
-            csp_id_set_build(&initials, &builder);
+            csp_id_set_remove(&initials, csp->tau);
             XDEBUG("Merged initials are ");
             DEBUG_EVENT_SET(&initials);
 
             /* For each of those events, union together the `afters` of that
              * event for all of the processes in the current set. */
-            for (j = 0; j < initials.count; j++) {
-                size_t k;
-                csp_id initial = initials.ids[j];
+            csp_id_set_foreach (&initials, &j) {
+                struct csp_id_set_iterator k;
+                csp_id initial = j.current;
                 csp_id after;
                 DEBUG("Get afters for %s", csp_get_event_name(csp, initial));
-                for (k = 0; k < current_processes->count; k++) {
-                    csp_id process = current_processes->ids[k];
+                csp_id_set_foreach (current_processes, &k) {
+                    csp_id process = k.current;
                     DEBUG("Get afters of " CSP_ID_FMT " for %s", process,
                           csp_get_event_name(csp, initial));
-                    csp_process_build_afters(csp, process, initial, &builder);
+                    csp_process_build_afters(csp, process, initial, &closure);
                 }
 
                 /* Calculate the τ-closure of that set. */
-                csp_id_set_build(&closure, &builder);
                 XDEBUG("Merged afters are ");
                 DEBUG_PROCESS_SET(&closure);
                 csp_process_find_closure(csp, csp->tau, &closure);
@@ -184,7 +180,7 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
                      * set so that we process it in the next iteration of the
                      * outer loop. */
                     DEBUG("Enqueue normalized node " CSP_ID_FMT, after);
-                    csp_id_set_builder_add(&pending_builder, after);
+                    csp_id_set_add(next_pending, after);
                 }
 
                 /* Add an edge to the normalized LTS. */
@@ -192,15 +188,14 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
             }
         }
 
-        /* Finalize the pending set for the next round. */
-        csp_id_set_build(&pending, &pending_builder);
+        /* Prepare the pending set for the next round. */
+        swap(current_pending, next_pending);
     }
 
     csp_id_set_done(&closure);
-    csp_id_set_done(&pending);
+    csp_id_set_done(&pending1);
+    csp_id_set_done(&pending2);
     csp_id_set_done(&initials);
-    csp_id_set_builder_done(&builder);
-    csp_id_set_builder_done(&pending_builder);
     return node;
 }
 
@@ -213,7 +208,6 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
     struct csp_id_pair_set_builder pending;
     struct csp_id_set initials;
     struct csp_id_set afters;
-    struct csp_id_set_builder builder;
     struct csp_behavior impl_behavior;
     struct csp_id_pair root = {normalized_spec, impl};
 
@@ -222,7 +216,6 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
     csp_id_pair_set_builder_init(&pending);
     csp_id_set_init(&initials);
     csp_id_set_init(&afters);
-    csp_id_set_builder_init(&builder);
     csp_behavior_init(&impl_behavior);
     csp_id_pair_set_builder_add(&pending, root);
     DEBUG("=== check " CSP_ID_FMT " ⊑T " CSP_ID_FMT, normalized_spec, impl);
@@ -232,7 +225,7 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
         csp_id_pair_set_build(&checking, &pending);
         DEBUG("--- new round; checking %zu pairs", checking.count);
         for (i = 0; i < checking.count; i++) {
-            size_t j;
+            struct csp_id_set_iterator j;
             const struct csp_id_pair *current = &checking.pairs[i];
             csp_id spec_node = current->from;
             csp_id impl_node = current->to;
@@ -255,11 +248,11 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
                 goto failure;
             }
 
-            csp_process_build_initials(csp, impl_node, &builder);
-            csp_id_set_build(&initials, &builder);
-            for (j = 0; j < initials.count; j++) {
-                size_t k;
-                csp_id initial = initials.ids[j];
+            csp_id_set_clear(&initials);
+            csp_process_build_initials(csp, impl_node, &initials);
+            csp_id_set_foreach (&initials, &j) {
+                struct csp_id_set_iterator k;
+                csp_id initial = j.current;
                 csp_id spec_after;
                 DEBUG("    impl -%s→ {...}", csp_get_event_name(csp, initial));
                 if (initial == csp->tau) {
@@ -276,10 +269,10 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
                 DEBUG("    spec -%s→ " CSP_ID_FMT,
                       csp_get_event_name(csp, initial), spec_after);
 
-                csp_process_build_afters(csp, impl_node, initial, &builder);
-                csp_id_set_build(&afters, &builder);
-                for (k = 0; k < afters.count; k++) {
-                    csp_id impl_after = afters.ids[k];
+                csp_id_set_clear(&afters);
+                csp_process_build_afters(csp, impl_node, initial, &afters);
+                csp_id_set_foreach (&afters, &k) {
+                    csp_id impl_after = k.current;
                     struct csp_id_pair next = {spec_after, impl_after};
                     DEBUG("    impl -%s→ " CSP_ID_FMT,
                           csp_get_event_name(csp, initial), impl_after);
@@ -300,7 +293,6 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
     csp_id_pair_set_builder_done(&pending);
     csp_id_set_done(&initials);
     csp_id_set_done(&afters);
-    csp_id_set_builder_done(&builder);
     csp_behavior_done(&impl_behavior);
     return true;
 
@@ -310,7 +302,6 @@ failure:
     csp_id_pair_set_builder_done(&pending);
     csp_id_set_done(&initials);
     csp_id_set_done(&afters);
-    csp_id_set_builder_done(&builder);
     csp_behavior_done(&impl_behavior);
     return false;
 }

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -42,26 +42,23 @@ TEST_CASE("can create events")
 TEST_CASE("predefined STOP process exists")
 {
     struct csp *csp;
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     /* Create the CSP environment. */
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the STOP process. */
-    csp_process_build_initials(csp, csp->stop, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_initials(csp, csp->stop, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of τ. */
-    csp_process_build_afters(csp, csp->stop, csp->tau, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_afters(csp, csp->stop, csp->tau, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of ✔. */
-    csp_process_build_afters(csp, csp->stop, csp->tick, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_afters(csp, csp->stop, csp->tick, &set);
     check_set_eq(&set, id_set());
     /* Clean up. */
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&set);
     csp_free(csp);
 }
@@ -69,26 +66,23 @@ TEST_CASE("predefined STOP process exists")
 TEST_CASE("predefined SKIP process exists")
 {
     struct csp *csp;
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     /* Create the CSP environment. */
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the SKIP process. */
-    csp_process_build_initials(csp, csp->skip, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_initials(csp, csp->skip, &set);
     check_set_eq(&set, id_set(csp->tick));
     /* Verify the afters of τ. */
-    csp_process_build_afters(csp, csp->skip, csp->tau, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_afters(csp, csp->skip, csp->tau, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of ✔. */
-    csp_process_build_afters(csp, csp->skip, csp->tick, &builder);
-    csp_id_set_build(&set, &builder);
+    csp_id_set_clear(&set);
+    csp_process_build_afters(csp, csp->skip, csp->tick, &set);
     check_set_eq(&set, id_set(csp->stop));
     /* Clean up. */
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&set);
     csp_free(csp);
 }

--- a/tests/test-id-sets.c
+++ b/tests/test-id-sets.c
@@ -12,252 +12,144 @@
 
 TEST_CASE_GROUP("identifier sets");
 
-static void
-csp_id_set_builder_add_range(struct csp_id_set_builder *builder, size_t count)
-{
-    size_t i;
-    for (i = 0; i < count; i++) {
-        csp_id_set_builder_add(builder, i);
-    }
-}
-
 TEST_CASE("can create empty set")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
     check_set_eq(&set, id_set());
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can add individual ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    check(csp_id_set_builder_add(&builder, 0));
-    check(csp_id_set_builder_add(&builder, 5));
-    check(csp_id_set_builder_add(&builder, 1));
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
+    check(csp_id_set_add(&set, 0));
+    check(csp_id_set_add(&set, 5));
+    check(csp_id_set_add(&set, 1));
     check_set_eq(&set, id_set(0, 1, 5));
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can add duplicate individual ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    check(csp_id_set_builder_add(&builder, 0));
-    check(csp_id_set_builder_add(&builder, 5));
-    check(csp_id_set_builder_add(&builder, 1));
-    check(!csp_id_set_builder_add(&builder, 5));
-    check(!csp_id_set_builder_add(&builder, 0));
-    check(!csp_id_set_builder_add(&builder, 0));
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    check(csp_id_set_add(&set, 0));
+    check(csp_id_set_add(&set, 5));
+    check(csp_id_set_add(&set, 1));
+    check(!csp_id_set_add(&set, 5));
+    check(!csp_id_set_add(&set, 0));
+    check(!csp_id_set_add(&set, 0));
     check_set_eq(&set, id_set(0, 1, 5));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can remove individual ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 0);
-    csp_id_set_builder_add(&builder, 5);
-    csp_id_set_builder_add(&builder, 1);
-    check(csp_id_set_builder_remove(&builder, 5));
-    check(!csp_id_set_builder_remove(&builder, 6));
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add(&set, 0);
+    csp_id_set_add(&set, 5);
+    csp_id_set_add(&set, 1);
+    check(csp_id_set_remove(&set, 5));
+    check(!csp_id_set_remove(&set, 6));
     check_set_eq(&set, id_set(0, 1));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can remove missing individual ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 0);
-    csp_id_set_builder_add(&builder, 5);
-    csp_id_set_builder_add(&builder, 1);
-    csp_id_set_builder_remove(&builder, 5);
-    csp_id_set_builder_remove(&builder, 7);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add(&set, 0);
+    csp_id_set_add(&set, 5);
+    csp_id_set_add(&set, 1);
+    csp_id_set_remove(&set, 5);
+    csp_id_set_remove(&set, 7);
     check_set_eq(&set, id_set(0, 1));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can add bulk ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     csp_id to_add[] = {0, 5, 1};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set, to_add_count, to_add);
     check_set_eq(&set, id_set(0, 1, 5));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can add duplicate bulk ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     csp_id to_add[] = {0, 5, 1, 5, 0, 0};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set, to_add_count, to_add);
     check_set_eq(&set, id_set(0, 1, 5));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can remove bulk ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     csp_id to_add[] = {0, 5, 1, 6};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     csp_id to_remove[] = {1, 5};
     size_t to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
-    csp_id_set_builder_remove_many(&builder, to_remove_count, to_remove);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set, to_add_count, to_add);
+    csp_id_set_remove_many(&set, to_remove_count, to_remove);
     check_set_eq(&set, id_set(0, 6));
     csp_id_set_done(&set);
 }
 
 TEST_CASE("can remove missing bulk ids")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set;
     csp_id to_add[] = {0, 5, 1, 6};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     csp_id to_remove[] = {1, 7};
     size_t to_remove_count = sizeof(to_remove) / sizeof(to_remove[0]);
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
-    csp_id_set_builder_remove_many(&builder, to_remove_count, to_remove);
     csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set, to_add_count, to_add);
+    csp_id_set_remove_many(&set, to_remove_count, to_remove);
     check_set_eq(&set, id_set(0, 5, 6));
     csp_id_set_done(&set);
 }
 
-TEST_CASE("can merge sets")
+TEST_CASE("can union sets")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set1;
     struct csp_id_set set2;
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 0);
-    csp_id_set_builder_add(&builder, 1);
     csp_id_set_init(&set1);
-    csp_id_set_build(&set1, &builder);
-    csp_id_set_builder_add(&builder, 5);
-    csp_id_set_builder_merge(&builder, &set1);
+    csp_id_set_add(&set1, 0);
+    csp_id_set_add(&set1, 1);
     csp_id_set_init(&set2);
-    csp_id_set_build(&set2, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add(&set2, 5);
+    csp_id_set_union(&set2, &set1);
     check_set_eq(&set2, id_set(0, 1, 5));
     csp_id_set_done(&set1);
     csp_id_set_done(&set2);
 }
 
-TEST_CASE("can empty a builder when building a set")
+TEST_CASE("can clone a set")
 {
-    struct csp_id_set_builder builder;
-    struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 0);
-    csp_id_set_builder_add(&builder, 5);
-    csp_id_set_builder_add(&builder, 1);
-    csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
-    check_set_eq(&set, id_set());
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can keep a builder full when building a set")
-{
-    struct csp_id_set_builder builder;
-    struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 0);
-    csp_id_set_builder_add(&builder, 5);
-    csp_id_set_builder_add(&builder, 1);
-    csp_id_set_init(&set);
-    csp_id_set_build_and_keep(&set, &builder);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
-    check_set_eq(&set, id_set(0, 1, 5));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can clone a small set")
-{
-    struct csp_id_set_builder builder;
     struct csp_id_set set1;
     struct csp_id_set set2;
     csp_id to_add[] = {0, 5, 1};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     /* Create a set. */
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set1);
-    csp_id_set_build(&set1, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set1, to_add_count, to_add);
     /* Then create a copy of it. */
     csp_id_set_init(&set2);
-    csp_id_set_clone(&set2, &set1);
+    csp_id_set_union(&set2, &set1);
     /* And verify its contents. */
     check_set_eq(&set2, id_set(0, 1, 5));
-    /* Clean up. */
-    csp_id_set_done(&set1);
-    csp_id_set_done(&set2);
-}
-
-TEST_CASE("can clone a large set")
-{
-    struct csp_id_set_builder builder;
-    struct csp_id_set set1;
-    struct csp_id_set set2;
-    /* Create a set. */
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_range(&builder,
-                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
-    csp_id_set_init(&set1);
-    csp_id_set_build(&set1, &builder);
-    csp_id_set_builder_done(&builder);
-    /* Then create a copy of it. */
-    csp_id_set_init(&set2);
-    csp_id_set_clone(&set2, &set1);
-    /* And verify its contents. */
-    check_set_eq(&set2, id_range_set(0, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1));
     /* Clean up. */
     csp_id_set_done(&set1);
     csp_id_set_done(&set2);
@@ -265,36 +157,22 @@ TEST_CASE("can clone a large set")
 
 TEST_CASE("can compare sets")
 {
-    struct csp_id_set_builder builder;
     struct csp_id_set set1;
     struct csp_id_set set2;
-    struct csp_id_set set3;
     csp_id to_add[] = {5, 1};
     size_t to_add_count = sizeof(to_add) / sizeof(to_add[0]);
     /* bulk */
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add_many(&builder, to_add_count, to_add);
     csp_id_set_init(&set1);
-    csp_id_set_build(&set1, &builder);
-    csp_id_set_builder_done(&builder);
+    csp_id_set_add_many(&set1, to_add_count, to_add);
     /* individual */
-    csp_id_set_builder_init(&builder);
-    csp_id_set_builder_add(&builder, 1);
-    csp_id_set_builder_add(&builder, 5);
     csp_id_set_init(&set2);
-    csp_id_set_build(&set2, &builder);
-    csp_id_set_builder_done(&builder);
-    /* shortcut */
-    csp_id_set_init(&set3);
-    csp_id_set_fill_double(&set3, 1, 5);
+    csp_id_set_add(&set2, 1);
+    csp_id_set_add(&set2, 5);
     /* compare */
     check(csp_id_set_eq(&set1, &set2));
-    check(csp_id_set_eq(&set1, &set3));
-    check(csp_id_set_eq(&set2, &set3));
     /* clean up */
     csp_id_set_done(&set1);
     csp_id_set_done(&set2);
-    csp_id_set_done(&set3);
 }
 
 TEST_CASE("can check subsets")
@@ -321,99 +199,4 @@ TEST_CASE("can check subsets")
     check(!csp_id_set_subseteq(id_set(4, 5), id_set(5)));
     check(!csp_id_set_subseteq(id_set(4, 5), id_set(5, 6)));
     check(!csp_id_set_subseteq(id_set(4, 5), id_set(6)));
-}
-
-TEST_CASE("can build a singleton set via shortcut")
-{
-    struct csp_id_set set;
-    csp_id_set_init(&set);
-    csp_id_set_fill_single(&set, 0);
-    check_set_eq(&set, id_set(0));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can build a doubleton set via shortcut")
-{
-    struct csp_id_set set;
-    csp_id_set_init(&set);
-    csp_id_set_fill_double(&set, 0, 1);
-    check_set_eq(&set, id_set(0, 1));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("doubleton shortcut builder sorts events")
-{
-    struct csp_id_set set;
-    csp_id_set_init(&set);
-    csp_id_set_fill_double(&set, 1, 0);
-    check_set_eq(&set, id_set(0, 1));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("doubleton shortcut builder deduplicates events")
-{
-    struct csp_id_set set;
-    csp_id_set_init(&set);
-    csp_id_set_fill_double(&set, 0, 0);
-    check_set_eq(&set, id_set(0));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can spill over into allocated storage")
-{
-    struct csp_id_set_builder builder;
-    struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    /* Fill the set with too many elements to fit into the preallocated internal
-     * storage, but few enough to fit into the default-sized heap-allocated
-     * buffer . */
-    csp_id_set_builder_add_range(&builder, CSP_ID_SET_INTERNAL_SIZE + 1);
-    csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
-    /* Verify that we got a valid set. */
-    check(set.allocated_count == CSP_ID_SET_FIRST_ALLOCATION_COUNT);
-    check_set_eq(&set, id_range_set(0, CSP_ID_SET_INTERNAL_SIZE + 1));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can spill over into large allocated storage")
-{
-    struct csp_id_set_builder builder;
-    struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    /* Fill the set with too many elements to fit into the preallocated internal
-     * storage, and too many too fit into the default-sized heap-allocated
-     * buffer. */
-    csp_id_set_builder_add_range(&builder,
-                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
-    csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
-    /* Verify that we got a valid set. */
-    check(set.allocated_count == CSP_ID_SET_FIRST_ALLOCATION_COUNT * 2);
-    check_set_eq(&set, id_range_set(0, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1));
-    csp_id_set_done(&set);
-}
-
-TEST_CASE("can reallocate allocated storage")
-{
-    struct csp_id_set_builder builder;
-    struct csp_id_set set;
-    csp_id_set_builder_init(&builder);
-    /* Fill the set with one too many elements to fit into the preallocated
-     * internal storage, causing an initial allocation. */
-    csp_id_set_builder_add_range(&builder, CSP_ID_SET_INTERNAL_SIZE + 1);
-    csp_id_set_init(&set);
-    csp_id_set_build(&set, &builder);
-    /* Then fill the set some more, to cause us to reallocate the heap-allocated
-     * storage. */
-    csp_id_set_builder_add_range(&builder,
-                                 CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1);
-    csp_id_set_build(&set, &builder);
-    csp_id_set_builder_done(&builder);
-    /* Verify that we got a valid set. */
-    check(set.allocated_count == CSP_ID_SET_FIRST_ALLOCATION_COUNT * 2);
-    check_set_eq(&set, id_range_set(0, CSP_ID_SET_FIRST_ALLOCATION_COUNT + 1));
-    csp_id_set_done(&set);
 }

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -27,16 +27,12 @@ check_process_initials(struct csp_id_factory process,
 {
     struct csp *csp;
     csp_id process_id;
-    struct csp_id_set_builder builder;
     struct csp_id_set actual;
     check_alloc(csp, csp_new());
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
-    csp_process_build_initials(csp, process_id, &builder);
-    csp_id_set_build(&actual, &builder);
+    csp_process_build_initials(csp, process_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_initials));
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&actual);
     csp_free(csp);
 }
@@ -50,17 +46,13 @@ check_process_afters(struct csp_id_factory process,
     struct csp *csp;
     csp_id process_id;
     csp_id initial_id;
-    struct csp_id_set_builder builder;
     struct csp_id_set actual;
     check_alloc(csp, csp_new());
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     initial_id = csp_id_factory_create(csp, initial);
-    csp_process_build_afters(csp, process_id, initial_id, &builder);
-    csp_id_set_build(&actual, &builder);
+    csp_process_build_afters(csp, process_id, initial_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_afters));
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&actual);
     csp_free(csp);
 }
@@ -80,6 +72,7 @@ check_process_traces_behavior(struct csp_id_factory process,
     expected_initials_set = csp_id_set_factory_create(csp, expected_initials);
     csp_process_get_behavior(csp, process_id, CSP_TRACES, &behavior);
     check_set_eq(&behavior.initials, expected_initials_set);
+    csp_behavior_done(&behavior);
     csp_free(csp);
 }
 
@@ -93,17 +86,13 @@ check_process_sub_initials(struct csp_id_factory process,
     struct csp *csp;
     UNNEEDED csp_id process_id;
     csp_id subprocess_id;
-    struct csp_id_set_builder builder;
     struct csp_id_set actual;
     check_alloc(csp, csp_new());
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     subprocess_id = csp_id_factory_create(csp, subprocess);
-    csp_process_build_initials(csp, subprocess_id, &builder);
-    csp_id_set_build(&actual, &builder);
+    csp_process_build_initials(csp, subprocess_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_initials));
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&actual);
     csp_free(csp);
 }
@@ -120,18 +109,14 @@ check_process_sub_afters(struct csp_id_factory process,
     UNNEEDED csp_id process_id;
     csp_id subprocess_id;
     csp_id initial_id;
-    struct csp_id_set_builder builder;
     struct csp_id_set actual;
     check_alloc(csp, csp_new());
-    csp_id_set_builder_init(&builder);
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     subprocess_id = csp_id_factory_create(csp, subprocess);
     initial_id = csp_id_factory_create(csp, initial);
-    csp_process_build_afters(csp, subprocess_id, initial_id, &builder);
-    csp_id_set_build(&actual, &builder);
+    csp_process_build_afters(csp, subprocess_id, initial_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_afters));
-    csp_id_set_builder_done(&builder);
     csp_id_set_done(&actual);
     csp_free(csp);
 }
@@ -155,6 +140,7 @@ check_process_sub_traces_behavior(struct csp_id_factory process,
     expected_initials_set = csp_id_set_factory_create(csp, expected_initials);
     csp_process_get_behavior(csp, subprocess_id, CSP_TRACES, &behavior);
     check_set_eq(&behavior.initials, expected_initials_set);
+    csp_behavior_done(&behavior);
     csp_free(csp);
 }
 


### PR DESCRIPTION
Having separate types for "locked, immutable" sets and "partially, mutable" set builders was more complex than we need.  Plus I don't think it made the code any faster.  This patch removes the set builder type completely.