### PR TITLE
Simplify process interface

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
-# Copyright © 2016, HST Project.
+# Copyright © 2016-2017, HST Project.
 # Please see the COPYING file in this distribution for license details.
 # ------------------------------------------------------------------------------
 
@@ -58,6 +58,8 @@ libhst_la_SOURCES = \
 	src/map.c \
 	src/normalized-lts.h \
 	src/normalized-lts.c \
+	src/process.h \
+	src/process.c \
 	src/refinement.h \
 	src/refinement.c \
 	src/string-map.h \

--- a/src/behavior.c
+++ b/src/behavior.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -50,7 +50,7 @@ static void
 csp_process_add_traces_behavior(struct csp *csp, csp_id process,
                                 struct csp_behavior *behavior)
 {
-    csp_process_build_initials(csp, process, &behavior->initials);
+    csp_build_process_initials(csp, process, &behavior->initials);
 }
 
 static void

--- a/src/environment.h
+++ b/src/environment.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 
 #include "id-set.h"
+#include "process.h"
 
 /*------------------------------------------------------------------------------
  * Environments
@@ -54,57 +55,22 @@ csp_get_sized_event_id(struct csp *csp, const char *name, size_t name_length);
 const char *
 csp_get_event_name(struct csp *csp, csp_id event);
 
-/*------------------------------------------------------------------------------
- * Processes
- */
+/* Register a process.  There must not already be a process registered with the
+ * same ID. */
+void
+csp_register_process(struct csp *csp, struct csp_process *process);
 
-struct csp_process_iface {
-    void (*initials)(struct csp *csp, struct csp_id_set *set, void *ud);
-
-    void (*afters)(struct csp *csp, csp_id initial, struct csp_id_set *set,
-                   void *ud);
-
-    csp_id (*get_id)(struct csp *csp, const void *temp_ud);
-
-    size_t (*ud_size)(struct csp *csp, const void *temp_ud);
-
-    void (*init_ud)(struct csp *csp, void *ud, const void *temp_ud);
-
-    void (*done_ud)(struct csp *csp, void *ud);
-};
-
-/* Creates a new process.
- *
- * You provide a userdata object that contains whatever you need to define the
- * new process, and an interface that defines several callbacks related to the
- * process.  You pass in a "temporary" userdata, which only needs to exist for
- * the duration of this function call.  (So it's safe to allocate on the stack,
- * for instance.)
- *
- * This function is safe to call multiple times for the "same" process (i.e., a
- * process with exactly the same definition).  The first thing we do is call the
- * process's `get_id` callback to produce the ID of the new process.  If there
- * is already an existing process with the same ID, then we do nothing else and
- * return the ID of the existing process.
- *
- * If the process is new, then we need to turn the "temporary" userdata into a
- * "permanent" one.  To do this, we'll first call the process's `ud_size`
- * callback, which should return the size of the permanent userdata.  We'll then
- * allocate this much memory, and call the process's `init_ud` callback to fill
- * it in from the temporary userdata.
- *
- * If `ud` is non-NULL, we will fill it in with a pointer to the permanent
- * userdata that we create for you. */
-csp_id
-csp_process_init(struct csp *csp, const void *temp_ud, void **ud,
-                 const struct csp_process_iface *iface);
+/* Return the process registered with a particular ID, or NULL if there isn't
+ * one. */
+struct csp_process *
+csp_get_process(struct csp *csp, csp_id id);
 
 void
-csp_process_build_initials(struct csp *csp, csp_id process,
+csp_build_process_initials(struct csp *csp, csp_id process_id,
                            struct csp_id_set *set);
 
 void
-csp_process_build_afters(struct csp *csp, csp_id process, csp_id initial,
+csp_build_process_afters(struct csp *csp, csp_id process_id, csp_id initial,
                          struct csp_id_set *set);
 
 /*------------------------------------------------------------------------------

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,12 +1,22 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
 
 #ifndef HST_MACROS_H
 #define HST_MACROS_H
+
+#include "ccan/likely/likely.h"
+
+#define return_if_nonnull(call)           \
+    do {                                  \
+        void *__result = (call);          \
+        if (unlikely(__result != NULL)) { \
+            return __result;              \
+        }                                 \
+    } while (0)
 
 #define swap(a, b)        \
     do {                  \

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -10,10 +10,14 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "macros.h"
+#include "process.h"
 
 struct csp_internal_choice {
+    struct csp_process process;
     struct csp_id_set ps;
 };
 
@@ -24,76 +28,76 @@ struct csp_internal_choice {
  */
 
 static void
-csp_internal_choice_initials(struct csp *csp, struct csp_id_set *set,
-                             void *vchoice)
+csp_internal_choice_initials(struct csp *csp, struct csp_process *process,
+                             struct csp_id_set *set)
 {
     /* initials(⊓ Ps) = {τ} */
     csp_id_set_add(set, csp->tau);
 }
 
 static void
-csp_internal_choice_afters(struct csp *csp, csp_id initial,
-                           struct csp_id_set *set, void *vchoice)
+csp_internal_choice_afters(struct csp *csp, struct csp_process *process,
+                           csp_id initial, struct csp_id_set *set)
 {
     /* afters(⊓ Ps, τ) = Ps */
-    struct csp_internal_choice *choice = vchoice;
+    struct csp_internal_choice *choice =
+            container_of(process, struct csp_internal_choice, process);
     if (initial == csp->tau) {
         csp_id_set_union(set, &choice->ps);
     }
 }
 
-static csp_id
-csp_internal_choice_get_id(struct csp *csp, const void *vps)
+static void
+csp_internal_choice_free(struct csp *csp, struct csp_process *process)
 {
-    const struct csp_id_set *ps = vps;
+    struct csp_internal_choice *choice =
+            container_of(process, struct csp_internal_choice, process);
+    csp_id_set_done(&choice->ps);
+    free(choice);
+}
+
+static csp_id
+csp_internal_choice_get_id(const struct csp_id_set *ps)
+{
     static struct csp_id_scope internal_choice;
     csp_id id = csp_id_start(&internal_choice);
     id = csp_id_add_id_set(id, ps);
     return id;
 }
 
-static size_t
-csp_internal_choice_ud_size(struct csp *csp, const void *temp_ud)
+static struct csp_process *
+csp_internal_choice_new(struct csp *csp, const struct csp_id_set *ps)
 {
-    return sizeof(struct csp_internal_choice);
-}
-
-static void
-csp_internal_choice_init(struct csp *csp, void *vchoice, const void *vps)
-{
-    struct csp_internal_choice *choice = vchoice;
-    const struct csp_id_set *ps = vps;
+    csp_id id = csp_internal_choice_get_id(ps);
+    struct csp_internal_choice *choice;
+    return_if_nonnull(csp_get_process(csp, id));
+    choice = malloc(sizeof(struct csp_internal_choice));
+    assert(choice != NULL);
+    choice->process.id = id;
+    choice->process.initials = csp_internal_choice_initials;
+    choice->process.afters = csp_internal_choice_afters;
+    choice->process.free = csp_internal_choice_free;
     csp_id_set_init(&choice->ps);
     csp_id_set_union(&choice->ps, ps);
+    csp_register_process(csp, &choice->process);
+    return &choice->process;
 }
-
-static void
-csp_internal_choice_done(struct csp *csp, void *vchoice)
-{
-    struct csp_internal_choice *choice = vchoice;
-    csp_id_set_done(&choice->ps);
-}
-
-static const struct csp_process_iface csp_internal_choice_iface = {
-        &csp_internal_choice_initials, &csp_internal_choice_afters,
-        &csp_internal_choice_get_id,   &csp_internal_choice_ud_size,
-        &csp_internal_choice_init,     &csp_internal_choice_done};
 
 csp_id
 csp_internal_choice(struct csp *csp, csp_id a, csp_id b)
 {
-    csp_id id;
+    struct csp_process *process;
     struct csp_id_set ps;
     csp_id_set_init(&ps);
     csp_id_set_add(&ps, a);
     csp_id_set_add(&ps, b);
-    id = csp_process_init(csp, &ps, NULL, &csp_internal_choice_iface);
+    process = csp_internal_choice_new(csp, &ps);
     csp_id_set_done(&ps);
-    return id;
+    return process->id;
 }
 
 csp_id
 csp_replicated_internal_choice(struct csp *csp, const struct csp_id_set *ps)
 {
-    return csp_process_init(csp, ps, NULL, &csp_internal_choice_iface);
+    return csp_internal_choice_new(csp, ps)->id;
 }

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -10,10 +10,14 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "macros.h"
+#include "process.h"
 
 struct csp_prefix {
+    struct csp_process process;
     csp_id a;
     csp_id p;
 };
@@ -25,63 +29,65 @@ struct csp_prefix {
  */
 
 static void
-csp_prefix_initials(struct csp *csp, struct csp_id_set *set, void *vprefix)
+csp_prefix_initials(struct csp *csp, struct csp_process *process,
+                    struct csp_id_set *set)
 {
     /* initials(a → P) = {a} */
-    struct csp_prefix *prefix = vprefix;
+    struct csp_prefix *prefix =
+            container_of(process, struct csp_prefix, process);
     csp_id_set_add(set, prefix->a);
 }
 
 static void
-csp_prefix_afters(struct csp *csp, csp_id initial, struct csp_id_set *set,
-                  void *vprefix)
+csp_prefix_afters(struct csp *csp, struct csp_process *process, csp_id initial,
+                  struct csp_id_set *set)
 {
     /* afters(a → P, a) = P */
-    struct csp_prefix *prefix = vprefix;
+    struct csp_prefix *prefix =
+            container_of(process, struct csp_prefix, process);
     if (initial == prefix->a) {
         csp_id_set_add(set, prefix->p);
     }
 }
 
-static csp_id
-csp_prefix_get_id(struct csp *csp, const void *vinput)
+static void
+csp_prefix_free(struct csp *csp, struct csp_process *process)
 {
-    const struct csp_prefix *input = vinput;
+    struct csp_prefix *prefix =
+            container_of(process, struct csp_prefix, process);
+    free(prefix);
+}
+
+static csp_id
+csp_prefix_get_id(csp_id a, csp_id p)
+{
     static struct csp_id_scope prefix;
     csp_id id = csp_id_start(&prefix);
-    id = csp_id_add_id(id, input->a);
-    id = csp_id_add_id(id, input->p);
+    id = csp_id_add_id(id, a);
+    id = csp_id_add_id(id, p);
     return id;
 }
 
-static size_t
-csp_prefix_ud_size(struct csp *csp, const void *vinput)
+static struct csp_process *
+csp_prefix_new(struct csp *csp, csp_id a, csp_id p)
 {
-    return sizeof(struct csp_prefix);
+    csp_id id = csp_prefix_get_id(a, p);
+    struct csp_prefix *prefix;
+    return_if_nonnull(csp_get_process(csp, id));
+    prefix = malloc(sizeof(struct csp_prefix));
+    assert(prefix != NULL);
+    prefix->process.id = id;
+    prefix->process.initials = csp_prefix_initials;
+    prefix->process.afters = csp_prefix_afters;
+    prefix->process.free = csp_prefix_free;
+    prefix->a = a;
+    prefix->p = p;
+    csp_register_process(csp, &prefix->process);
+    return &prefix->process;
 }
-
-static void
-csp_prefix_init(struct csp *csp, void *vprefix, const void *vinput)
-{
-    struct csp_prefix *prefix = vprefix;
-    const struct csp_prefix *input = vinput;
-    prefix->a = input->a;
-    prefix->p = input->p;
-}
-
-static void
-csp_prefix_done(struct csp *csp, void *vprefix)
-{
-    /* nothing to do */
-}
-
-static const struct csp_process_iface csp_prefix_iface = {
-        &csp_prefix_initials, &csp_prefix_afters, &csp_prefix_get_id,
-        &csp_prefix_ud_size,  &csp_prefix_init,   &csp_prefix_done};
 
 csp_id
 csp_prefix(struct csp *csp, csp_id a, csp_id p)
 {
-    struct csp_prefix input = {a, p};
-    return csp_process_init(csp, &input, NULL, &csp_prefix_iface);
+    return csp_prefix_new(csp, a, p)->id;
 }

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,32 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "process.h"
+
+#include "basics.h"
+#include "environment.h"
+#include "id-set.h"
+
+void
+csp_process_free(struct csp *csp, struct csp_process *process)
+{
+    process->free(csp, process);
+}
+
+void
+csp_process_build_initials(struct csp *csp, struct csp_process *process,
+                           struct csp_id_set *set)
+{
+    process->initials(csp, process, set);
+}
+
+void
+csp_process_build_afters(struct csp *csp, struct csp_process *process,
+                         csp_id initial, struct csp_id_set *set)
+{
+    process->afters(csp, process, initial, set);
+}

--- a/src/process.h
+++ b/src/process.h
@@ -1,0 +1,43 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_PROCESS_H
+#define HST_PROCESS_H
+
+#include "basics.h"
+#include "id-set.h"
+
+/*------------------------------------------------------------------------------
+ * Processes
+ */
+
+struct csp;
+
+struct csp_process {
+    csp_id id;
+
+    void (*initials)(struct csp *csp, struct csp_process *process,
+                     struct csp_id_set *set);
+
+    void (*afters)(struct csp *csp, struct csp_process *process, csp_id initial,
+                   struct csp_id_set *set);
+
+    void (*free)(struct csp *csp, struct csp_process *process);
+};
+
+void
+csp_process_free(struct csp *csp, struct csp_process *process);
+
+void
+csp_process_build_initials(struct csp *csp, struct csp_process *process,
+                           struct csp_id_set *set);
+
+void
+csp_process_build_afters(struct csp *csp, struct csp_process *process,
+                         csp_id initial, struct csp_id_set *set);
+
+#endif /* HST_PROCESS_H */

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -87,7 +87,7 @@ csp_process_find_closure(struct csp *csp, csp_id event,
             DEBUG("process " CSP_ID_FMT, process);
             /* Enqueue each of the states that we can reach from `process` by
              * following a single `event`. */
-            csp_process_build_afters(csp, process, event, next_queue);
+            csp_build_process_afters(csp, process, event, next_queue);
         }
         another_round_needed = csp_id_set_union(processes, next_queue);
         swap(current_queue, next_queue);
@@ -148,7 +148,7 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
             csp_id_set_foreach (current_processes, &j) {
                 csp_id process = csp_id_set_iterator_get(&j);
                 DEBUG("Get initials of " CSP_ID_FMT, process);
-                csp_process_build_initials(csp, process, &initials);
+                csp_build_process_initials(csp, process, &initials);
             }
             csp_id_set_remove(&initials, csp->tau);
             XDEBUG("Merged initials are ");
@@ -165,7 +165,7 @@ csp_process_prenormalize(struct csp *csp, struct csp_normalized_lts *lts,
                     csp_id process = csp_id_set_iterator_get(&k);
                     DEBUG("Get afters of " CSP_ID_FMT " for %s", process,
                           csp_get_event_name(csp, initial));
-                    csp_process_build_afters(csp, process, initial, &closure);
+                    csp_build_process_afters(csp, process, initial, &closure);
                 }
 
                 /* Calculate the τ-closure of that set. */
@@ -250,7 +250,7 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
             }
 
             csp_id_set_clear(&initials);
-            csp_process_build_initials(csp, impl_node, &initials);
+            csp_build_process_initials(csp, impl_node, &initials);
             csp_id_set_foreach (&initials, &j) {
                 struct csp_id_set_iterator k;
                 csp_id initial = csp_id_set_iterator_get(&j);
@@ -271,7 +271,7 @@ csp_check_traces_refinement(struct csp *csp, struct csp_normalized_lts *lts,
                       csp_get_event_name(csp, initial), spec_after);
 
                 csp_id_set_clear(&afters);
-                csp_process_build_afters(csp, impl_node, initial, &afters);
+                csp_build_process_afters(csp, impl_node, initial, &afters);
                 csp_id_set_foreach (&afters, &k) {
                     csp_id impl_after = csp_id_set_iterator_get(&k);
                     struct csp_id_pair next = {spec_after, impl_after};

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -47,15 +47,15 @@ TEST_CASE("predefined STOP process exists")
     check_alloc(csp, csp_new());
     /* Verify the initials set of the STOP process. */
     csp_id_set_clear(&set);
-    csp_process_build_initials(csp, csp->stop, &set);
+    csp_build_process_initials(csp, csp->stop, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of τ. */
     csp_id_set_clear(&set);
-    csp_process_build_afters(csp, csp->stop, csp->tau, &set);
+    csp_build_process_afters(csp, csp->stop, csp->tau, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of ✔. */
     csp_id_set_clear(&set);
-    csp_process_build_afters(csp, csp->stop, csp->tick, &set);
+    csp_build_process_afters(csp, csp->stop, csp->tick, &set);
     check_set_eq(&set, id_set());
     /* Clean up. */
     csp_id_set_done(&set);
@@ -71,15 +71,15 @@ TEST_CASE("predefined SKIP process exists")
     check_alloc(csp, csp_new());
     /* Verify the initials set of the SKIP process. */
     csp_id_set_clear(&set);
-    csp_process_build_initials(csp, csp->skip, &set);
+    csp_build_process_initials(csp, csp->skip, &set);
     check_set_eq(&set, id_set(csp->tick));
     /* Verify the afters of τ. */
     csp_id_set_clear(&set);
-    csp_process_build_afters(csp, csp->skip, csp->tau, &set);
+    csp_build_process_afters(csp, csp->skip, csp->tau, &set);
     check_set_eq(&set, id_set());
     /* Verify the afters of ✔. */
     csp_id_set_clear(&set);
-    csp_process_build_afters(csp, csp->skip, csp->tick, &set);
+    csp_build_process_afters(csp, csp->skip, csp->tick, &set);
     check_set_eq(&set, id_set(csp->stop));
     /* Clean up. */
     csp_id_set_done(&set);

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -34,7 +34,7 @@ check_process_initials(struct csp_id_factory process,
     check_alloc(csp, csp_new());
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
-    csp_process_build_initials(csp, process_id, &actual);
+    csp_build_process_initials(csp, process_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_initials));
     csp_id_set_done(&actual);
     csp_free(csp);
@@ -54,7 +54,7 @@ check_process_afters(struct csp_id_factory process,
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     initial_id = csp_id_factory_create(csp, initial);
-    csp_process_build_afters(csp, process_id, initial_id, &actual);
+    csp_build_process_afters(csp, process_id, initial_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_afters));
     csp_id_set_done(&actual);
     csp_free(csp);
@@ -94,7 +94,7 @@ check_process_sub_initials(struct csp_id_factory process,
     csp_id_set_init(&actual);
     process_id = csp_id_factory_create(csp, process);
     subprocess_id = csp_id_factory_create(csp, subprocess);
-    csp_process_build_initials(csp, subprocess_id, &actual);
+    csp_build_process_initials(csp, subprocess_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_initials));
     csp_id_set_done(&actual);
     csp_free(csp);
@@ -118,7 +118,7 @@ check_process_sub_afters(struct csp_id_factory process,
     process_id = csp_id_factory_create(csp, process);
     subprocess_id = csp_id_factory_create(csp, subprocess);
     initial_id = csp_id_factory_create(csp, initial);
-    csp_process_build_afters(csp, subprocess_id, initial_id, &actual);
+    csp_build_process_afters(csp, subprocess_id, initial_id, &actual);
     check_set_eq(&actual, csp_id_set_factory_create(csp, expected_afters));
     csp_id_set_done(&actual);
     csp_free(csp);


### PR DESCRIPTION
Jeez that was way too complex.  Each operator has its own type (as before), but now with a copy of `struct csp_process` embedded inside of them.  I've also thrown away the whole "temporary userdata" nonsense.  Each operator constructor now explicitly checks to see whether there's already a process with the same ID, returning it directly if so.  If the process is new, we allocate it using a perfectly standard `malloc(3)` call.