### PR TITLE
Move process callbacks into a vtable

### DIFF
--- a/src/environment.c
+++ b/src/environment.c
@@ -52,6 +52,9 @@ csp_stop_free(struct csp *csp, struct csp_process *process)
 {
 }
 
+static const struct csp_process_iface csp_stop_iface = {
+        csp_stop_initials, csp_stop_afters, csp_stop_free};
+
 static struct csp_process *
 csp_stop(void)
 {
@@ -59,10 +62,7 @@ csp_stop(void)
     static bool initialized = false;
     if (unlikely(!initialized)) {
         stop.id = hash_name("STOP");
-        stop.initials = csp_stop_initials;
-        stop.afters = csp_stop_afters;
-        stop.free = csp_stop_free;
-        initialized = true;
+        stop.iface = &csp_stop_iface;
     }
     return &stop;
 }
@@ -88,6 +88,9 @@ csp_skip_free(struct csp *csp, struct csp_process *process)
 {
 }
 
+static const struct csp_process_iface csp_skip_iface = {
+        csp_skip_initials, csp_skip_afters, csp_skip_free};
+
 static struct csp_process *
 csp_skip(void)
 {
@@ -95,9 +98,7 @@ csp_skip(void)
     static bool initialized = false;
     if (unlikely(!initialized)) {
         skip.id = hash_name("skip");
-        skip.initials = csp_skip_initials;
-        skip.afters = csp_skip_afters;
-        skip.free = csp_skip_free;
+        skip.iface = &csp_skip_iface;
         initialized = true;
     }
     return &skip;

--- a/src/operators/external-choice.c
+++ b/src/operators/external-choice.c
@@ -121,6 +121,10 @@ csp_external_choice_free(struct csp *csp, struct csp_process *process)
     free(choice);
 }
 
+static const struct csp_process_iface csp_external_choice_iface = {
+        csp_external_choice_initials, csp_external_choice_afters,
+        csp_external_choice_free};
+
 static csp_id
 csp_external_choice_get_id(const struct csp_id_set *ps)
 {
@@ -139,9 +143,7 @@ csp_external_choice_new(struct csp *csp, const struct csp_id_set *ps)
     choice = malloc(sizeof(struct csp_external_choice));
     assert(choice != NULL);
     choice->process.id = id;
-    choice->process.initials = csp_external_choice_initials;
-    choice->process.afters = csp_external_choice_afters;
-    choice->process.free = csp_external_choice_free;
+    choice->process.iface = &csp_external_choice_iface;
     csp_id_set_init(&choice->ps);
     csp_id_set_union(&choice->ps, ps);
     csp_register_process(csp, &choice->process);

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -56,6 +56,10 @@ csp_internal_choice_free(struct csp *csp, struct csp_process *process)
     free(choice);
 }
 
+static const struct csp_process_iface csp_internal_choice_iface = {
+        csp_internal_choice_initials, csp_internal_choice_afters,
+        csp_internal_choice_free};
+
 static csp_id
 csp_internal_choice_get_id(const struct csp_id_set *ps)
 {
@@ -74,9 +78,7 @@ csp_internal_choice_new(struct csp *csp, const struct csp_id_set *ps)
     choice = malloc(sizeof(struct csp_internal_choice));
     assert(choice != NULL);
     choice->process.id = id;
-    choice->process.initials = csp_internal_choice_initials;
-    choice->process.afters = csp_internal_choice_afters;
-    choice->process.free = csp_internal_choice_free;
+    choice->process.iface = &csp_internal_choice_iface;
     csp_id_set_init(&choice->ps);
     csp_id_set_union(&choice->ps, ps);
     csp_register_process(csp, &choice->process);

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -58,6 +58,9 @@ csp_prefix_free(struct csp *csp, struct csp_process *process)
     free(prefix);
 }
 
+static const struct csp_process_iface csp_prefix_iface = {
+        csp_prefix_initials, csp_prefix_afters, csp_prefix_free};
+
 static csp_id
 csp_prefix_get_id(csp_id a, csp_id p)
 {
@@ -77,9 +80,7 @@ csp_prefix_new(struct csp *csp, csp_id a, csp_id p)
     prefix = malloc(sizeof(struct csp_prefix));
     assert(prefix != NULL);
     prefix->process.id = id;
-    prefix->process.initials = csp_prefix_initials;
-    prefix->process.afters = csp_prefix_afters;
-    prefix->process.free = csp_prefix_free;
+    prefix->process.iface = &csp_prefix_iface;
     prefix->a = a;
     prefix->p = p;
     csp_register_process(csp, &prefix->process);

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -61,6 +61,10 @@ csp_recursive_process_free(struct csp *csp, struct csp_process *process)
     free(recursive_process);
 }
 
+static const struct csp_process_iface csp_recursive_process_iface = {
+        csp_recursive_process_initials, csp_recursive_process_afters,
+        csp_recursive_process_free};
+
 static struct csp_process *
 csp_recursive_process_new(struct csp *csp, csp_id id)
 {
@@ -69,9 +73,7 @@ csp_recursive_process_new(struct csp *csp, csp_id id)
     recursive_process = malloc(sizeof(struct csp_recursive_process));
     assert(recursive_process != NULL);
     recursive_process->process.id = id;
-    recursive_process->process.initials = csp_recursive_process_initials;
-    recursive_process->process.afters = csp_recursive_process_afters;
-    recursive_process->process.free = csp_recursive_process_free;
+    recursive_process->process.iface = &csp_recursive_process_iface;
     recursive_process->definition = CSP_PROCESS_NONE;
     csp_register_process(csp, &recursive_process->process);
     return &recursive_process->process;

--- a/src/operators/sequential-composition.c
+++ b/src/operators/sequential-composition.c
@@ -107,6 +107,10 @@ csp_sequential_composition_free(struct csp *csp, struct csp_process *process)
     free(seq);
 }
 
+static const struct csp_process_iface csp_sequential_composition_iface = {
+        csp_sequential_composition_initials, csp_sequential_composition_afters,
+        csp_sequential_composition_free};
+
 static csp_id
 csp_sequential_composition_get_id(csp_id p, csp_id q)
 {
@@ -126,9 +130,7 @@ csp_sequential_composition_new(struct csp *csp, csp_id p, csp_id q)
     seq = malloc(sizeof(struct csp_sequential_composition));
     assert(seq != NULL);
     seq->process.id = id;
-    seq->process.initials = csp_sequential_composition_initials;
-    seq->process.afters = csp_sequential_composition_afters;
-    seq->process.free = csp_sequential_composition_free;
+    seq->process.iface = &csp_sequential_composition_iface;
     seq->p = p;
     seq->q = q;
     csp_register_process(csp, &seq->process);

--- a/src/process.c
+++ b/src/process.c
@@ -14,19 +14,19 @@
 void
 csp_process_free(struct csp *csp, struct csp_process *process)
 {
-    process->free(csp, process);
+    process->iface->free(csp, process);
 }
 
 void
 csp_process_build_initials(struct csp *csp, struct csp_process *process,
                            struct csp_id_set *set)
 {
-    process->initials(csp, process, set);
+    process->iface->initials(csp, process, set);
 }
 
 void
 csp_process_build_afters(struct csp *csp, struct csp_process *process,
                          csp_id initial, struct csp_id_set *set)
 {
-    process->afters(csp, process, initial, set);
+    process->iface->afters(csp, process, initial, set);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -16,10 +16,9 @@
  */
 
 struct csp;
+struct csp_process;
 
-struct csp_process {
-    csp_id id;
-
+struct csp_process_iface {
     void (*initials)(struct csp *csp, struct csp_process *process,
                      struct csp_id_set *set);
 
@@ -27,6 +26,11 @@ struct csp_process {
                    struct csp_id_set *set);
 
     void (*free)(struct csp *csp, struct csp_process *process);
+};
+
+struct csp_process {
+    csp_id id;
+    const struct csp_process_iface *iface;
 };
 
 void


### PR DESCRIPTION
No need to copy all three of them into each and every process object.