### PR TITLE
Use visitor to handle process's initials

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -65,6 +65,11 @@ csp_register_process(struct csp *csp, struct csp_process *process);
 struct csp_process *
 csp_get_process(struct csp *csp, csp_id id);
 
+/* Return the process registered with a particular ID, which is required to
+ * exist. */
+struct csp_process *
+csp_require_process(struct csp *csp, csp_id id);
+
 void
 csp_build_process_initials(struct csp *csp, csp_id process_id,
                            struct csp_id_set *set);

--- a/src/operators/external-choice.c
+++ b/src/operators/external-choice.c
@@ -34,7 +34,7 @@ struct csp_external_choice {
 
 static void
 csp_external_choice_initials(struct csp *csp, struct csp_process *process,
-                             struct csp_id_set *set)
+                             struct csp_event_visitor *visitor)
 {
     /* 1) If P ∈ Ps can perform τ, then □ Ps can perform τ.
      * 2) If P ∈ Ps can perform a ≠ τ, then □ Ps can perform a ≠ τ.
@@ -48,7 +48,9 @@ csp_external_choice_initials(struct csp *csp, struct csp_process *process,
             container_of(process, struct csp_external_choice, process);
     struct csp_id_set_iterator i;
     csp_id_set_foreach (&choice->ps, &i) {
-        csp_build_process_initials(csp, csp_id_set_iterator_get(&i), set);
+        csp_id process_id = csp_id_set_iterator_get(&i);
+        struct csp_process *p = csp_require_process(csp, process_id);
+        csp_process_visit_initials(csp, p, visitor);
     }
 }
 

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -29,10 +29,10 @@ struct csp_internal_choice {
 
 static void
 csp_internal_choice_initials(struct csp *csp, struct csp_process *process,
-                             struct csp_id_set *set)
+                             struct csp_event_visitor *visitor)
 {
     /* initials(⊓ Ps) = {τ} */
-    csp_id_set_add(set, csp->tau);
+    csp_event_visitor_call(csp, visitor, csp->tau);
 }
 
 static void

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -30,12 +30,12 @@ struct csp_prefix {
 
 static void
 csp_prefix_initials(struct csp *csp, struct csp_process *process,
-                    struct csp_id_set *set)
+                    struct csp_event_visitor *visitor)
 {
     /* initials(a → P) = {a} */
     struct csp_prefix *prefix =
             container_of(process, struct csp_prefix, process);
-    csp_id_set_add(set, prefix->a);
+    csp_event_visitor_call(csp, visitor, prefix->a);
 }
 
 static void

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -35,12 +35,14 @@ struct csp_recursive_process {
 
 static void
 csp_recursive_process_initials(struct csp *csp, struct csp_process *process,
-                               struct csp_id_set *set)
+                               struct csp_event_visitor *visitor)
 {
     struct csp_recursive_process *recursive_process =
             container_of(process, struct csp_recursive_process, process);
+    struct csp_process *definition;
     assert(recursive_process->definition != CSP_PROCESS_NONE);
-    csp_build_process_initials(csp, recursive_process->definition, set);
+    definition = csp_require_process(csp, recursive_process->definition);
+    csp_process_visit_initials(csp, definition, visitor);
 }
 
 static void

--- a/src/process.h
+++ b/src/process.h
@@ -11,16 +11,37 @@
 #include "basics.h"
 #include "id-set.h"
 
+struct csp;
+struct csp_process;
+
+/*------------------------------------------------------------------------------
+ * Event visitors
+ */
+
+struct csp_event_visitor {
+    void (*visit)(struct csp *csp, struct csp_event_visitor *visitor,
+                  csp_id event);
+};
+
+void
+csp_event_visitor_call(struct csp *csp, struct csp_event_visitor *visitor,
+                       csp_id event);
+
+struct csp_collect_events {
+    struct csp_event_visitor visitor;
+    struct csp_id_set *set;
+};
+
+struct csp_collect_events
+csp_collect_events(struct csp_id_set *set);
+
 /*------------------------------------------------------------------------------
  * Processes
  */
 
-struct csp;
-struct csp_process;
-
 struct csp_process_iface {
     void (*initials)(struct csp *csp, struct csp_process *process,
-                     struct csp_id_set *set);
+                     struct csp_event_visitor *visitor);
 
     void (*afters)(struct csp *csp, struct csp_process *process, csp_id initial,
                    struct csp_id_set *set);
@@ -37,8 +58,8 @@ void
 csp_process_free(struct csp *csp, struct csp_process *process);
 
 void
-csp_process_build_initials(struct csp *csp, struct csp_process *process,
-                           struct csp_id_set *set);
+csp_process_visit_initials(struct csp *csp, struct csp_process *process,
+                           struct csp_event_visitor *visitor);
 
 void
 csp_process_build_afters(struct csp *csp, struct csp_process *process,


### PR DESCRIPTION
Instead of rendering the initials into a set, you now provide a callback that should be used to process each initial in turn.  We're using the same container_of trick to embed the visitor callback inside of whatever closure state the callback needs to operate.

The legacy function for grabbing the initials via a process ID still renders everything into a set, which will let us migrate each caller over to the new visitor pattern one by one.