### PR TITLE
Use visitor to handle process's afters

### DIFF
--- a/src/environment.c
+++ b/src/environment.c
@@ -43,7 +43,7 @@ csp_stop_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_stop_afters(struct csp *csp, struct csp_process *process, csp_id initial,
-                struct csp_id_set *set)
+                struct csp_edge_visitor *visitor)
 {
 }
 
@@ -76,10 +76,10 @@ csp_skip_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_skip_afters(struct csp *csp, struct csp_process *process, csp_id initial,
-                struct csp_id_set *set)
+                struct csp_edge_visitor *visitor)
 {
     if (initial == csp->tick) {
-        csp_id_set_add(set, csp->stop);
+        csp_edge_visitor_call(csp, visitor, initial, csp->stop);
     }
 }
 
@@ -244,8 +244,7 @@ csp_build_process_initials(struct csp *csp, csp_id process_id,
                            struct csp_id_set *set)
 {
     struct csp_process *process = csp_require_process(csp, process_id);
-    struct csp_collect_events collect;
-    collect = csp_collect_events(set);
+    struct csp_collect_events collect = csp_collect_events(set);
     csp_process_visit_initials(csp, process, &collect.visitor);
 }
 
@@ -254,7 +253,8 @@ csp_build_process_afters(struct csp *csp, csp_id process_id, csp_id initial,
                          struct csp_id_set *set)
 {
     struct csp_process *process = csp_require_process(csp, process_id);
-    csp_process_build_afters(csp, process, initial, set);
+    struct csp_collect_afters collect = csp_collect_afters(set);
+    csp_process_visit_afters(csp, process, initial, &collect.visitor);
 }
 
 csp_id

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -37,13 +37,17 @@ csp_internal_choice_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_internal_choice_afters(struct csp *csp, struct csp_process *process,
-                           csp_id initial, struct csp_id_set *set)
+                           csp_id initial, struct csp_edge_visitor *visitor)
 {
     /* afters(⊓ Ps, τ) = Ps */
     struct csp_internal_choice *choice =
             container_of(process, struct csp_internal_choice, process);
     if (initial == csp->tau) {
-        csp_id_set_union(set, &choice->ps);
+        struct csp_id_set_iterator iter;
+        csp_id_set_foreach (&choice->ps, &iter) {
+            csp_id p = csp_id_set_iterator_get(&iter);
+            csp_edge_visitor_call(csp, visitor, initial, p);
+        }
     }
 }
 

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -40,13 +40,13 @@ csp_prefix_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_prefix_afters(struct csp *csp, struct csp_process *process, csp_id initial,
-                  struct csp_id_set *set)
+                  struct csp_edge_visitor *visitor)
 {
     /* afters(a → P, a) = P */
     struct csp_prefix *prefix =
             container_of(process, struct csp_prefix, process);
     if (initial == prefix->a) {
-        csp_id_set_add(set, prefix->p);
+        csp_edge_visitor_call(csp, visitor, initial, prefix->p);
     }
 }
 

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -47,12 +47,14 @@ csp_recursive_process_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_recursive_process_afters(struct csp *csp, struct csp_process *process,
-                             csp_id initial, struct csp_id_set *set)
+                             csp_id initial, struct csp_edge_visitor *visitor)
 {
     struct csp_recursive_process *recursive_process =
             container_of(process, struct csp_recursive_process, process);
+    struct csp_process *definition;
     assert(recursive_process->definition != CSP_PROCESS_NONE);
-    csp_build_process_afters(csp, recursive_process->definition, initial, set);
+    definition = csp_require_process(csp, recursive_process->definition);
+    csp_process_visit_afters(csp, definition, initial, visitor);
 }
 
 static void

--- a/src/operators/sequential-composition.c
+++ b/src/operators/sequential-composition.c
@@ -86,7 +86,8 @@ csp_sequential_composition_initials(struct csp *csp,
 
 static void
 csp_sequential_composition_afters(struct csp *csp, struct csp_process *process,
-                                  csp_id initial, struct csp_id_set *set)
+                                  csp_id initial,
+                                  struct csp_edge_visitor *visitor)
 {
     /* afters(P;Q a ≠ ✔) = afters(P, a)                                 [rule 1]
      * afters(P;Q, τ) = Q  if ✔ ∈ initials(P)                           [rule 2]
@@ -113,7 +114,7 @@ csp_sequential_composition_afters(struct csp *csp, struct csp_process *process,
     csp_id_set_foreach (&afters, &i) {
         csp_id p_prime = csp_id_set_iterator_get(&i);
         csp_id seq_prime = csp_sequential_composition(csp, p_prime, seq->q);
-        csp_id_set_add(set, seq_prime);
+        csp_edge_visitor_call(csp, visitor, initial, seq_prime);
     }
 
     /* If P can perform a ✔ leading to P', then P;Q can perform a τ leading to
@@ -124,7 +125,7 @@ csp_sequential_composition_afters(struct csp *csp, struct csp_process *process,
         if (!csp_id_set_empty(&afters)) {
             /* A can perform ✔, and we don't actually care what it leads to,
              * since we're going to lead to Q no matter what. */
-            csp_id_set_add(set, seq->q);
+            csp_edge_visitor_call(csp, visitor, initial, seq->q);
         }
     }
 

--- a/src/process.c
+++ b/src/process.c
@@ -40,6 +40,33 @@ csp_collect_events(struct csp_id_set *set)
 }
 
 /*------------------------------------------------------------------------------
+ * Edge visitors
+ */
+
+void
+csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
+                      csp_id event, csp_id after)
+{
+    visitor->visit(csp, visitor, event, after);
+}
+
+static void
+csp_collect_afters_visit(struct csp *csp, struct csp_edge_visitor *visitor,
+                         csp_id event, csp_id after)
+{
+    struct csp_collect_afters *self =
+            container_of(visitor, struct csp_collect_afters, visitor);
+    csp_id_set_add(self->set, after);
+}
+
+struct csp_collect_afters
+csp_collect_afters(struct csp_id_set *set)
+{
+    struct csp_collect_afters self = {{csp_collect_afters_visit}, set};
+    return self;
+}
+
+/*------------------------------------------------------------------------------
  * Processes
  */
 
@@ -57,8 +84,8 @@ csp_process_visit_initials(struct csp *csp, struct csp_process *process,
 }
 
 void
-csp_process_build_afters(struct csp *csp, struct csp_process *process,
-                         csp_id initial, struct csp_id_set *set)
+csp_process_visit_afters(struct csp *csp, struct csp_process *process,
+                         csp_id initial, struct csp_edge_visitor *visitor)
 {
-    process->iface->afters(csp, process, initial, set);
+    process->iface->afters(csp, process, initial, visitor);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -36,6 +36,27 @@ struct csp_collect_events
 csp_collect_events(struct csp_id_set *set);
 
 /*------------------------------------------------------------------------------
+ * Edge visitors
+ */
+
+struct csp_edge_visitor {
+    void (*visit)(struct csp *csp, struct csp_edge_visitor *visitor,
+                  csp_id event, csp_id after);
+};
+
+void
+csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
+                      csp_id event, csp_id after);
+
+struct csp_collect_afters {
+    struct csp_edge_visitor visitor;
+    struct csp_id_set *set;
+};
+
+struct csp_collect_afters
+csp_collect_afters(struct csp_id_set *set);
+
+/*------------------------------------------------------------------------------
  * Processes
  */
 
@@ -44,7 +65,7 @@ struct csp_process_iface {
                      struct csp_event_visitor *visitor);
 
     void (*afters)(struct csp *csp, struct csp_process *process, csp_id initial,
-                   struct csp_id_set *set);
+                   struct csp_edge_visitor *visitor);
 
     void (*free)(struct csp *csp, struct csp_process *process);
 };
@@ -62,7 +83,7 @@ csp_process_visit_initials(struct csp *csp, struct csp_process *process,
                            struct csp_event_visitor *visitor);
 
 void
-csp_process_build_afters(struct csp *csp, struct csp_process *process,
-                         csp_id initial, struct csp_id_set *set);
+csp_process_visit_afters(struct csp *csp, struct csp_process *process,
+                         csp_id initial, struct csp_edge_visitor *visitor);
 
 #endif /* HST_PROCESS_H */


### PR DESCRIPTION
Just like we just did for the `initials` method, you now pass in a visitor to a process's `afters` method instead of a set.  And just like with the `initials`, the legacy function for grabbing the afters via a process ID still renders everything into a set, allowing us to migrate things one by one.