### PR TITLE
Add sets of processes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ check_PROGRAMS = \
 	tests/test-id-pairs \
 	tests/test-id-set-maps \
 	tests/test-id-sets \
+	tests/test-process-sets \
 	tests/test-operators \
 	tests/test-refinement
 bin_PROGRAMS = hst
@@ -104,6 +105,7 @@ tests_test_id_pairs_LDFLAGS = -no-install
 tests_test_id_set_maps_LDFLAGS = -no-install
 tests_test_id_sets_LDFLAGS = -no-install
 tests_test_operators_LDFLAGS = -no-install
+tests_test_process_sets_LDFLAGS = -no-install
 tests_test_refinement_LDFLAGS = -no-install
 
 dist_doc_DATA = README.md

--- a/src/event.c
+++ b/src/event.c
@@ -246,3 +246,28 @@ csp_event_set_union(struct csp_event_set *set,
 {
     return csp_set_union(&set->set, &other->set);
 }
+
+void
+csp_event_set_get_iterator(const struct csp_event_set *set,
+                           struct csp_event_set_iterator *iter)
+{
+    csp_set_get_iterator(&set->set, &iter->iter);
+}
+
+const struct csp_event *
+csp_event_set_iterator_get(const struct csp_event_set_iterator *iter)
+{
+    return csp_set_iterator_get(&iter->iter);
+}
+
+bool
+csp_event_set_iterator_done(struct csp_event_set_iterator *iter)
+{
+    return csp_set_iterator_done(&iter->iter);
+}
+
+void
+csp_event_set_iterator_advance(struct csp_event_set_iterator *iter)
+{
+    csp_set_iterator_advance(&iter->iter);
+}

--- a/src/process.c
+++ b/src/process.c
@@ -239,3 +239,88 @@ csp_process_bfs(struct csp *csp, struct csp_process *root,
     }
     csp_process_bfs_done(&self);
 }
+
+/*------------------------------------------------------------------------------
+ * Process sets
+ */
+
+void
+csp_process_set_init(struct csp_process_set *set)
+{
+    csp_set_init(&set->set);
+}
+
+void
+csp_process_set_done(struct csp_process_set *set)
+{
+    csp_set_done(&set->set, NULL, NULL);
+}
+
+bool
+csp_process_set_empty(const struct csp_process_set *set)
+{
+    return csp_set_empty(&set->set);
+}
+
+size_t
+csp_process_set_size(const struct csp_process_set *set)
+{
+    return csp_set_size(&set->set);
+}
+
+bool
+csp_process_set_eq(const struct csp_process_set *set1,
+                   const struct csp_process_set *set2)
+{
+    return csp_set_eq(&set1->set, &set2->set);
+}
+
+void
+csp_process_set_clear(struct csp_process_set *set)
+{
+    csp_set_clear(&set->set, NULL, NULL);
+}
+
+bool
+csp_process_set_add(struct csp_process_set *set, struct csp_process *process)
+{
+    return csp_set_add(&set->set, (void *) process);
+}
+
+bool
+csp_process_set_remove(struct csp_process_set *set, struct csp_process *process)
+{
+    return csp_set_remove(&set->set, (void *) process);
+}
+
+bool
+csp_process_set_union(struct csp_process_set *set,
+                      const struct csp_process_set *other)
+{
+    return csp_set_union(&set->set, &other->set);
+}
+
+void
+csp_process_set_get_iterator(const struct csp_process_set *set,
+                             struct csp_process_set_iterator *iter)
+{
+    csp_set_get_iterator(&set->set, &iter->iter);
+}
+
+struct csp_process *
+csp_process_set_iterator_get(const struct csp_process_set_iterator *iter)
+{
+    return csp_set_iterator_get(&iter->iter);
+}
+
+bool
+csp_process_set_iterator_done(struct csp_process_set_iterator *iter)
+{
+    return csp_set_iterator_done(&iter->iter);
+}
+
+void
+csp_process_set_iterator_advance(struct csp_process_set_iterator *iter)
+{
+    csp_set_iterator_advance(&iter->iter);
+}

--- a/src/process.h
+++ b/src/process.h
@@ -124,4 +124,70 @@ void
 csp_process_bfs(struct csp *csp, struct csp_process *process,
                 struct csp_process_visitor *visitor);
 
+/*------------------------------------------------------------------------------
+ * Process sets
+ */
+
+struct csp_process_set {
+    struct csp_set set;
+};
+
+void
+csp_process_set_init(struct csp_process_set *set);
+
+void
+csp_process_set_done(struct csp_process_set *set);
+
+bool
+csp_process_set_empty(const struct csp_process_set *set);
+
+size_t
+csp_process_set_size(const struct csp_process_set *set);
+
+bool
+csp_process_set_eq(const struct csp_process_set *set1,
+                   const struct csp_process_set *set2);
+
+void
+csp_process_set_clear(struct csp_process_set *set);
+
+/* Add a single process to a set.  Return whether the process is new (i.e., it
+ * wasn't already in `set`.) */
+bool
+csp_process_set_add(struct csp_process_set *set, struct csp_process *process);
+
+/* Remove a single process from a set.  Returns whether that process was in the
+ * set or not. */
+bool
+csp_process_set_remove(struct csp_process_set *set,
+                       struct csp_process *process);
+
+/* Add the contents of an existing set to a set.  Returns true if any new
+ * elements were added. */
+bool
+csp_process_set_union(struct csp_process_set *set,
+                      const struct csp_process_set *other);
+
+struct csp_process_set_iterator {
+    struct csp_set_iterator iter;
+};
+
+void
+csp_process_set_get_iterator(const struct csp_process_set *set,
+                             struct csp_process_set_iterator *iter);
+
+struct csp_process *
+csp_process_set_iterator_get(const struct csp_process_set_iterator *iter);
+
+bool
+csp_process_set_iterator_done(struct csp_process_set_iterator *iter);
+
+void
+csp_process_set_iterator_advance(struct csp_process_set_iterator *iter);
+
+#define csp_process_set_foreach(set, iter)            \
+    for (csp_process_set_get_iterator((set), (iter)); \
+         !csp_process_set_iterator_done((iter));      \
+         csp_process_set_iterator_advance((iter)))
+
 #endif /* HST_PROCESS_H */

--- a/tests/test-event-sets.c
+++ b/tests/test-event-sets.c
@@ -70,7 +70,7 @@ TEST_CASE("can create empty set")
     csp_event_set_done(&set);
 }
 
-TEST_CASE("can add individual events")
+TEST_CASE("can add events")
 {
     struct csp_event_set set;
     csp_event_set_init(&set);
@@ -81,7 +81,7 @@ TEST_CASE("can add individual events")
     csp_event_set_done(&set);
 }
 
-TEST_CASE("can add duplicate individual events")
+TEST_CASE("can add duplicate events")
 {
     struct csp_event_set set;
     csp_event_set_init(&set);
@@ -95,7 +95,7 @@ TEST_CASE("can add duplicate individual events")
     csp_event_set_done(&set);
 }
 
-TEST_CASE("can remove individual events")
+TEST_CASE("can remove events")
 {
     struct csp_event_set set;
     csp_event_set_init(&set);
@@ -107,7 +107,7 @@ TEST_CASE("can remove individual events")
     csp_event_set_done(&set);
 }
 
-TEST_CASE("can remove missing individual events")
+TEST_CASE("can remove missing events")
 {
     struct csp_event_set set;
     csp_event_set_init(&set);

--- a/tests/test-process-sets.c
+++ b/tests/test-process-sets.c
@@ -1,0 +1,155 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "process.h"
+
+#include "test-case-harness.h"
+
+static struct csp_process p0;
+static struct csp_process p1;
+static struct csp_process p2;
+static struct csp_process p5;
+static struct csp_process p6;
+
+static void
+csp_process_set_free_(void *vset)
+{
+    struct csp_process_set *set = vset;
+    csp_process_set_done(set);
+    free(set);
+}
+
+/* Creates a new empty set.  The set will be automatically freed for you at the
+ * end of the test case. */
+static struct csp_process_set *
+empty_process_set(void)
+{
+    struct csp_process_set *set = malloc(sizeof(struct csp_process_set));
+    assert(set != NULL);
+    csp_process_set_init(set);
+    test_case_cleanup_register(csp_process_set_free_, set);
+    return set;
+}
+
+/* Creates a new set containing the given processes.  The set will be
+ * automatically freed for you at the end of the test case. */
+#define process_set(...)                                 \
+    CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
+    (process_set_(LENGTH(__VA_ARGS__), __VA_ARGS__))(empty_process_set())
+
+static struct csp_process_set *
+process_set_(size_t count, ...)
+{
+    size_t i;
+    va_list args;
+    struct csp_process_set *set = malloc(sizeof(struct csp_process_set));
+    assert(set != NULL);
+    csp_process_set_init(set);
+    test_case_cleanup_register(csp_process_set_free_, set);
+    va_start(args, count);
+    for (i = 0; i < count; i++) {
+        struct csp_process *process = va_arg(args, struct csp_process *);
+        csp_process_set_add(set, process);
+    }
+    va_end(args);
+    return set;
+}
+
+TEST_CASE_GROUP("process sets");
+
+TEST_CASE("can create empty set")
+{
+    struct csp_process_set set;
+    csp_process_set_init(&set);
+    check(csp_process_set_eq(&set, process_set()));
+    csp_process_set_done(&set);
+}
+
+TEST_CASE("can add ids")
+{
+    struct csp_process_set set;
+    csp_process_set_init(&set);
+    check(csp_process_set_add(&set, &p0));
+    check(csp_process_set_add(&set, &p5));
+    check(csp_process_set_add(&set, &p1));
+    check(csp_process_set_eq(&set, process_set(&p0, &p1, &p5)));
+    csp_process_set_done(&set);
+}
+
+TEST_CASE("can add duplicate ids")
+{
+    struct csp_process_set set;
+    csp_process_set_init(&set);
+    check(csp_process_set_add(&set, &p0));
+    check(csp_process_set_add(&set, &p5));
+    check(csp_process_set_add(&set, &p1));
+    check(!csp_process_set_add(&set, &p5));
+    check(!csp_process_set_add(&set, &p0));
+    check(!csp_process_set_add(&set, &p0));
+    check(csp_process_set_eq(&set, process_set(&p0, &p1, &p5)));
+    csp_process_set_done(&set);
+}
+
+TEST_CASE("can remove ids")
+{
+    struct csp_process_set set;
+    csp_process_set_init(&set);
+    csp_process_set_add(&set, &p0);
+    csp_process_set_add(&set, &p5);
+    csp_process_set_add(&set, &p1);
+    check(csp_process_set_remove(&set, &p5));
+    check(!csp_process_set_remove(&set, &p6));
+    check(csp_process_set_eq(&set, process_set(&p0, &p1)));
+    csp_process_set_done(&set);
+}
+
+TEST_CASE("can remove missing ids")
+{
+    struct csp_process_set set;
+    csp_process_set_init(&set);
+    csp_process_set_add(&set, &p0);
+    csp_process_set_add(&set, &p5);
+    csp_process_set_add(&set, &p1);
+    csp_process_set_remove(&set, &p5);
+    csp_process_set_remove(&set, &p2);
+    check(csp_process_set_eq(&set, process_set(&p0, &p1)));
+    csp_process_set_done(&set);
+}
+
+TEST_CASE("can union sets")
+{
+    struct csp_process_set set1;
+    struct csp_process_set set2;
+    csp_process_set_init(&set1);
+    csp_process_set_add(&set1, &p0);
+    csp_process_set_add(&set1, &p1);
+    csp_process_set_init(&set2);
+    csp_process_set_add(&set2, &p5);
+    csp_process_set_union(&set2, &set1);
+    check(csp_process_set_eq(&set2, process_set(&p0, &p1, &p5)));
+    csp_process_set_done(&set1);
+    csp_process_set_done(&set2);
+}
+
+TEST_CASE("can compare sets")
+{
+    struct csp_process_set set1;
+    struct csp_process_set set2;
+    /* bulk */
+    csp_process_set_init(&set1);
+    csp_process_set_add(&set1, &p5);
+    csp_process_set_add(&set1, &p1);
+    /* */
+    csp_process_set_init(&set2);
+    csp_process_set_add(&set2, &p1);
+    csp_process_set_add(&set2, &p5);
+    /* compare */
+    check(csp_process_set_eq(&set1, &set2));
+    /* clean up */
+    csp_process_set_done(&set1);
+    csp_process_set_done(&set2);
+}


### PR DESCRIPTION
Eventually we won't need `csp_id_set` anymore, since we'll have replaced each use of it with `csp_event_set` and `csp_process_set`.