### PR TITLE
Use event objects in process interface

### DIFF
--- a/src/behavior.c
+++ b/src/behavior.c
@@ -11,17 +11,18 @@
 
 #include "ccan/likely/likely.h"
 #include "environment.h"
+#include "event.h"
 
 void
 csp_behavior_init(struct csp_behavior *behavior)
 {
-    csp_id_set_init(&behavior->initials);
+    csp_event_set_init(&behavior->initials);
 }
 
 void
 csp_behavior_done(struct csp_behavior *behavior)
 {
-    csp_id_set_done(&behavior->initials);
+    csp_event_set_done(&behavior->initials);
 }
 
 bool
@@ -33,7 +34,7 @@ csp_behavior_eq(const struct csp_behavior *b1, const struct csp_behavior *b2)
     if (unlikely(b1->model != b2->model)) {
         return false;
     }
-    return csp_id_set_eq(&b1->initials, &b2->initials);
+    return csp_event_set_eq(&b1->initials, &b2->initials);
 }
 
 bool
@@ -43,7 +44,7 @@ csp_behavior_refines(const struct csp_behavior *spec,
     if (unlikely(spec->model != impl->model)) {
         return false;
     }
-    return csp_id_set_subseteq(&impl->initials, &spec->initials);
+    return csp_event_set_subseteq(&impl->initials, &spec->initials);
 }
 
 static void
@@ -57,15 +58,15 @@ static void
 csp_behavior_finish_traces(struct csp *csp, struct csp_behavior *behavior)
 {
     behavior->model = CSP_TRACES;
-    csp_id_set_remove(&behavior->initials, csp->tau);
-    behavior->hash = csp_id_set_hash(&behavior->initials);
+    csp_event_set_remove(&behavior->initials, csp->tau);
+    behavior->hash = csp_event_set_hash(&behavior->initials);
 }
 
 static void
 csp_process_get_traces_behavior(struct csp *csp, csp_id process,
                                 struct csp_behavior *behavior)
 {
-    csp_id_set_clear(&behavior->initials);
+    csp_event_set_clear(&behavior->initials);
     csp_process_add_traces_behavior(csp, process, behavior);
     csp_behavior_finish_traces(csp, behavior);
 }
@@ -90,7 +91,7 @@ csp_process_set_get_traces_behavior(struct csp *csp,
                                     struct csp_behavior *behavior)
 {
     struct csp_id_set_iterator iter;
-    csp_id_set_clear(&behavior->initials);
+    csp_event_set_clear(&behavior->initials);
     csp_id_set_foreach (processes, &iter) {
         csp_process_add_traces_behavior(csp, csp_id_set_iterator_get(&iter),
                                         behavior);

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -10,6 +10,7 @@
 
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 
 /*------------------------------------------------------------------------------
  * Process behavior
@@ -20,7 +21,7 @@ enum csp_semantic_model { CSP_TRACES };
 struct csp_behavior {
     enum csp_semantic_model model;
     csp_id hash;
-    struct csp_id_set initials;
+    struct csp_event_set initials;
 };
 
 void

--- a/src/csp0.c
+++ b/src/csp0.c
@@ -311,7 +311,7 @@ parse_process2(struct csp0_parse_state *state, csp_id *dest)
         skip_whitespace(state);
         require(parse_process2(state, &after));
         event = csp_event_get_sized(id.start, id.length);
-        *dest = csp_prefix(state->csp, csp_event_id(event), after);
+        *dest = csp_prefix(state->csp, event, after);
         DEBUG("ACCEPT process2 → " CSP_ID_FMT, *dest);
         return 0;
     }

--- a/src/environment.c
+++ b/src/environment.c
@@ -42,7 +42,8 @@ csp_stop_initials(struct csp *csp, struct csp_process *process,
 }
 
 static void
-csp_stop_afters(struct csp *csp, struct csp_process *process, csp_id initial,
+csp_stop_afters(struct csp *csp, struct csp_process *process,
+                const struct csp_event *initial,
                 struct csp_edge_visitor *visitor)
 {
 }
@@ -75,7 +76,8 @@ csp_skip_initials(struct csp *csp, struct csp_process *process,
 }
 
 static void
-csp_skip_afters(struct csp *csp, struct csp_process *process, csp_id initial,
+csp_skip_afters(struct csp *csp, struct csp_process *process,
+                const struct csp_event *initial,
                 struct csp_edge_visitor *visitor)
 {
     if (initial == csp->tick) {
@@ -165,8 +167,8 @@ csp_new(void)
     }
     csp_id_process_map_init(&csp->processes);
     csp->next_recursion_scope_id = 0;
-    csp->public.tau = csp_event_id(csp_tau());
-    csp->public.tick = csp_event_id(csp_tick());
+    csp->public.tau = csp_tau();
+    csp->public.tick = csp_tick();
     csp->stop = csp_stop();
     csp_register_process(&csp->public, csp->stop);
     csp->public.stop = csp->stop->id;
@@ -211,7 +213,7 @@ csp_require_process(struct csp *csp, csp_id id)
 
 void
 csp_build_process_initials(struct csp *csp, csp_id process_id,
-                           struct csp_id_set *set)
+                           struct csp_event_set *set)
 {
     struct csp_process *process = csp_require_process(csp, process_id);
     struct csp_collect_events collect = csp_collect_events(set);
@@ -219,7 +221,8 @@ csp_build_process_initials(struct csp *csp, csp_id process_id,
 }
 
 void
-csp_build_process_afters(struct csp *csp, csp_id process_id, csp_id initial,
+csp_build_process_afters(struct csp *csp, csp_id process_id,
+                         const struct csp_event *initial,
                          struct csp_id_set *set)
 {
     struct csp_process *process = csp_require_process(csp, process_id);
@@ -231,6 +234,12 @@ csp_id
 csp_id_start(struct csp_id_scope *scope)
 {
     return hash64_any(&scope, sizeof(struct csp_id_scope *), 0);
+}
+
+csp_id
+csp_id_add_event(csp_id id, const struct csp_event *event)
+{
+    return hash64_any(&event, sizeof(const struct csp_event *), id);
 }
 
 csp_id

--- a/src/environment.h
+++ b/src/environment.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "event.h"
 #include "id-set.h"
 #include "process.h"
 
@@ -27,8 +28,8 @@ typedef uint64_t csp_id;
 #define CSP_PROCESS_NONE CSP_ID_NONE
 
 struct csp {
-    csp_id tau;
-    csp_id tick;
+    const struct csp_event *tau;
+    const struct csp_event *tick;
     csp_id skip;
     csp_id stop;
 };
@@ -57,10 +58,11 @@ csp_require_process(struct csp *csp, csp_id id);
 
 void
 csp_build_process_initials(struct csp *csp, csp_id process_id,
-                           struct csp_id_set *set);
+                           struct csp_event_set *set);
 
 void
-csp_build_process_afters(struct csp *csp, csp_id process_id, csp_id initial,
+csp_build_process_afters(struct csp *csp, csp_id process_id,
+                         const struct csp_event *initial,
                          struct csp_id_set *set);
 
 /*------------------------------------------------------------------------------
@@ -108,6 +110,9 @@ struct csp_id_scope {
 
 csp_id
 csp_id_start(struct csp_id_scope *scope);
+
+csp_id
+csp_id_add_event(csp_id id, const struct csp_event *event);
 
 csp_id
 csp_id_add_id(csp_id id, csp_id id_to_add);

--- a/src/event.c
+++ b/src/event.c
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -81,12 +82,6 @@ csp_event_map_at(struct csp_event_map *map, csp_id id)
     return (const struct csp_event **) csp_map_at(&map->map, id);
 }
 
-static const struct csp_event *
-csp_event_map_get(struct csp_event_map *map, csp_id id)
-{
-    return csp_map_get(&map->map, id);
-}
-
 static struct csp_event_map events;
 
 static void
@@ -135,15 +130,6 @@ csp_event_get_sized(const char *name, size_t name_length)
     return *event;
 }
 
-const struct csp_event *
-csp_event_get_by_id(csp_id event_id)
-{
-    struct csp_event_map *map = get_event_map();
-    const struct csp_event *event = csp_event_map_get(map, event_id);
-    assert(event != NULL);
-    return event;
-}
-
 csp_id
 csp_event_id(const struct csp_event *event)
 {
@@ -184,6 +170,8 @@ csp_tick(void)
  * Event sets
  */
 
+#define CSP_EVENT_SET_INITIAL_HASH UINT64_C(0xbe70ef9046515956) /* random */
+
 void
 csp_event_set_init(struct csp_event_set *set)
 {
@@ -194,6 +182,12 @@ void
 csp_event_set_done(struct csp_event_set *set)
 {
     csp_set_done(&set->set, NULL, NULL);
+}
+
+uint64_t
+csp_event_set_hash(const struct csp_event_set *set)
+{
+    return csp_set_hash(&set->set, CSP_EVENT_SET_INITIAL_HASH);
 }
 
 bool

--- a/src/event.h
+++ b/src/event.h
@@ -40,10 +40,6 @@ const struct csp_event *
 csp_event_get_sized(const char *name, size_t name_length);
 
 PURE_FUNCTION
-const struct csp_event *
-csp_event_get_by_id(csp_id id);
-
-PURE_FUNCTION
 csp_id
 csp_event_id(const struct csp_event *event);
 
@@ -64,6 +60,9 @@ csp_event_set_init(struct csp_event_set *set);
 
 void
 csp_event_set_done(struct csp_event_set *set);
+
+uint64_t
+csp_event_set_hash(const struct csp_event_set *set);
 
 bool
 csp_event_set_empty(const struct csp_event_set *set);

--- a/src/normalization.h
+++ b/src/normalization.h
@@ -11,6 +11,7 @@
 #include "basics.h"
 #include "environment.h"
 #include "equivalence.h"
+#include "event.h"
 #include "id-set.h"
 #include "process.h"
 
@@ -66,7 +67,7 @@ csp_normalized_process_get_processes(struct csp *csp,
  * guaranteed to have zero or one `after` for each event.) */
 struct csp_process *
 csp_process_get_single_after(struct csp *csp, struct csp_process *process,
-                             csp_id initial);
+                             const struct csp_event *initial);
 
 /* Finds the closure of a set of processes for a particular event.  This is the
  * set of processes that can be reached from any of the initial processes by
@@ -77,7 +78,7 @@ csp_process_get_single_after(struct csp *csp, struct csp_process *process,
  * for; it will be updated to contain all of the processes in the closure (which
  * must always include the initial processes). */
 void
-csp_find_process_closure(struct csp *csp, csp_id event,
+csp_find_process_closure(struct csp *csp, const struct csp_event *event,
                          struct csp_id_set *processes);
 
 /* Bisimulate all of the nodes in a prenormalized process, to find nodes that

--- a/src/operators.h
+++ b/src/operators.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -12,6 +12,7 @@
 
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "map.h"
 
 /*------------------------------------------------------------------------------
@@ -28,7 +29,7 @@ csp_id
 csp_internal_choice(struct csp *csp, csp_id p, csp_id q);
 
 csp_id
-csp_prefix(struct csp *csp, csp_id a, csp_id p);
+csp_prefix(struct csp *csp, const struct csp_event *a, csp_id p);
 
 csp_id
 csp_replicated_external_choice(struct csp *csp, const struct csp_id_set *ps);

--- a/src/operators/external-choice.c
+++ b/src/operators/external-choice.c
@@ -13,6 +13,7 @@
 #include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "macros.h"
 #include "process.h"
 
@@ -56,7 +57,8 @@ csp_external_choice_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_external_choice_afters(struct csp *csp, struct csp_process *process,
-                           csp_id initial, struct csp_edge_visitor *visitor)
+                           const struct csp_event *initial,
+                           struct csp_edge_visitor *visitor)
 {
     /* afters(□ Ps, τ) = ⋃ { □ Ps ∖ {P} ∪ {P'} | P ∈ Ps, P' ∈ afters(P, τ) }
      *                                                                  [rule 1]

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -13,6 +13,7 @@
 #include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "macros.h"
 #include "process.h"
 
@@ -37,7 +38,8 @@ csp_internal_choice_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_internal_choice_afters(struct csp *csp, struct csp_process *process,
-                           csp_id initial, struct csp_edge_visitor *visitor)
+                           const struct csp_event *initial,
+                           struct csp_edge_visitor *visitor)
 {
     /* afters(⊓ Ps, τ) = Ps */
     struct csp_internal_choice *choice =

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -13,12 +13,13 @@
 #include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "macros.h"
 #include "process.h"
 
 struct csp_prefix {
     struct csp_process process;
-    csp_id a;
+    const struct csp_event *a;
     csp_id p;
 };
 
@@ -39,7 +40,8 @@ csp_prefix_initials(struct csp *csp, struct csp_process *process,
 }
 
 static void
-csp_prefix_afters(struct csp *csp, struct csp_process *process, csp_id initial,
+csp_prefix_afters(struct csp *csp, struct csp_process *process,
+                  const struct csp_event *initial,
                   struct csp_edge_visitor *visitor)
 {
     /* afters(a → P, a) = P */
@@ -62,17 +64,17 @@ static const struct csp_process_iface csp_prefix_iface = {
         csp_prefix_initials, csp_prefix_afters, csp_prefix_free};
 
 static csp_id
-csp_prefix_get_id(csp_id a, csp_id p)
+csp_prefix_get_id(const struct csp_event *a, csp_id p)
 {
     static struct csp_id_scope prefix;
     csp_id id = csp_id_start(&prefix);
-    id = csp_id_add_id(id, a);
+    id = csp_id_add_event(id, a);
     id = csp_id_add_id(id, p);
     return id;
 }
 
 static struct csp_process *
-csp_prefix_new(struct csp *csp, csp_id a, csp_id p)
+csp_prefix_new(struct csp *csp, const struct csp_event *a, csp_id p)
 {
     csp_id id = csp_prefix_get_id(a, p);
     struct csp_prefix *prefix;
@@ -88,7 +90,7 @@ csp_prefix_new(struct csp *csp, csp_id a, csp_id p)
 }
 
 csp_id
-csp_prefix(struct csp *csp, csp_id a, csp_id p)
+csp_prefix(struct csp *csp, const struct csp_event *a, csp_id p)
 {
     return csp_prefix_new(csp, a, p)->id;
 }

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -15,6 +15,7 @@
 #include "ccan/likely/likely.h"
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "macros.h"
 #include "process.h"
 
@@ -47,7 +48,8 @@ csp_recursive_process_initials(struct csp *csp, struct csp_process *process,
 
 static void
 csp_recursive_process_afters(struct csp *csp, struct csp_process *process,
-                             csp_id initial, struct csp_edge_visitor *visitor)
+                             const struct csp_event *initial,
+                             struct csp_edge_visitor *visitor)
 {
     struct csp_recursive_process *recursive_process =
             container_of(process, struct csp_recursive_process, process);

--- a/src/operators/sequential-composition.c
+++ b/src/operators/sequential-composition.c
@@ -13,6 +13,7 @@
 #include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
+#include "event.h"
 #include "macros.h"
 #include "process.h"
 
@@ -27,7 +28,8 @@ struct csp_translate_tick_to_tau {
 
 static void
 csp_translate_tick_to_tau_visit(struct csp *csp,
-                                struct csp_event_visitor *visitor, csp_id event)
+                                struct csp_event_visitor *visitor,
+                                const struct csp_event *event)
 {
     struct csp_translate_tick_to_tau *self =
             container_of(visitor, struct csp_translate_tick_to_tau, visitor);
@@ -86,7 +88,7 @@ csp_sequential_composition_initials(struct csp *csp,
 
 static void
 csp_sequential_composition_afters(struct csp *csp, struct csp_process *process,
-                                  csp_id initial,
+                                  const struct csp_event *initial,
                                   struct csp_edge_visitor *visitor)
 {
     /* afters(P;Q a ≠ ✔) = afters(P, a)                                 [rule 1]

--- a/src/process.h
+++ b/src/process.h
@@ -9,6 +9,7 @@
 #define HST_PROCESS_H
 
 #include "basics.h"
+#include "event.h"
 #include "id-set.h"
 
 struct csp;
@@ -20,29 +21,30 @@ struct csp_process;
 
 struct csp_event_visitor {
     void (*visit)(struct csp *csp, struct csp_event_visitor *visitor,
-                  csp_id event);
+                  const struct csp_event *event);
 };
 
 void
 csp_event_visitor_call(struct csp *csp, struct csp_event_visitor *visitor,
-                       csp_id event);
+                       const struct csp_event *event);
 
 struct csp_collect_events {
     struct csp_event_visitor visitor;
-    struct csp_id_set *set;
+    struct csp_event_set *set;
 };
 
 struct csp_collect_events
-csp_collect_events(struct csp_id_set *set);
+csp_collect_events(struct csp_event_set *set);
 
 struct csp_ignore_event {
     struct csp_event_visitor visitor;
     struct csp_event_visitor *wrapped;
-    csp_id event;
+    const struct csp_event *event;
 };
 
 struct csp_ignore_event
-csp_ignore_event(struct csp_event_visitor *wrapped, csp_id event);
+csp_ignore_event(struct csp_event_visitor *wrapped,
+                 const struct csp_event *event);
 
 /*------------------------------------------------------------------------------
  * Edge visitors
@@ -50,12 +52,12 @@ csp_ignore_event(struct csp_event_visitor *wrapped, csp_id event);
 
 struct csp_edge_visitor {
     void (*visit)(struct csp *csp, struct csp_edge_visitor *visitor,
-                  csp_id event, csp_id after);
+                  const struct csp_event *event, csp_id after);
 };
 
 void
 csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
-                      csp_id event, csp_id after);
+                      const struct csp_event *event, csp_id after);
 
 struct csp_collect_afters {
     struct csp_edge_visitor visitor;
@@ -94,7 +96,8 @@ struct csp_process_iface {
     void (*initials)(struct csp *csp, struct csp_process *process,
                      struct csp_event_visitor *visitor);
 
-    void (*afters)(struct csp *csp, struct csp_process *process, csp_id initial,
+    void (*afters)(struct csp *csp, struct csp_process *process,
+                   const struct csp_event *initial,
                    struct csp_edge_visitor *visitor);
 
     void (*free)(struct csp *csp, struct csp_process *process);
@@ -114,7 +117,8 @@ csp_process_visit_initials(struct csp *csp, struct csp_process *process,
 
 void
 csp_process_visit_afters(struct csp *csp, struct csp_process *process,
-                         csp_id initial, struct csp_edge_visitor *visitor);
+                         const struct csp_event *initial,
+                         struct csp_edge_visitor *visitor);
 
 void
 csp_process_visit_transitions(struct csp *csp, struct csp_process *process,

--- a/src/refinement.h
+++ b/src/refinement.h
@@ -10,8 +10,8 @@
 
 #include <stdbool.h>
 
-#include "basics.h"
 #include "environment.h"
+#include "process.h"
 
 /*------------------------------------------------------------------------------
  * Refinement

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -19,12 +19,6 @@
  * things by hand.  Look in test-operators.c for test cases that verify that
  * each operator behaves as we expect it to. */
 
-static csp_id
-csp_get_event_id(const char *event_name)
-{
-    return csp_event_id(csp_event_get(event_name));
-}
-
 #define check_csp0_eq(str, expected)                         \
     do {                                                     \
         csp_id __actual;                                     \
@@ -130,13 +124,11 @@ TEST_CASE_GROUP("CSP₀ operators");
 TEST_CASE("parse: a → STOP □ SKIP")
 {
     struct csp *csp;
-    csp_id a;
     csp_id p0;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    p0 = csp_prefix(csp, a, csp->stop);
+    p0 = csp_prefix(csp, csp_event_get("a"), csp->stop);
     root = csp_external_choice(csp, p0, csp->skip);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a->STOP[]SKIP", root);
@@ -164,9 +156,6 @@ TEST_CASE("parse: a → STOP □ SKIP")
 TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
-    csp_id c;
     csp_id p1;
     csp_id p2;
     csp_id p3;
@@ -174,12 +163,9 @@ TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP")
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    c = csp_get_event_id("c");
-    p1 = csp_prefix(csp, a, csp->stop);
-    p2 = csp_prefix(csp, b, csp->stop);
-    p3 = csp_prefix(csp, c, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
+    p2 = csp_prefix(csp, csp_event_get("b"), csp->stop);
+    p3 = csp_prefix(csp, csp_event_get("c"), csp->stop);
     p4 = csp_external_choice(csp, p2, p3);
     root = csp_external_choice(csp, p1, p4);
     /* Verify that we can parse the process, with and without whitespace. */
@@ -192,13 +178,11 @@ TEST_CASE("associativity: a → STOP □ b → STOP □ c → STOP")
 TEST_CASE("parse: a → STOP ⊓ SKIP")
 {
     struct csp *csp;
-    csp_id a;
     csp_id p1;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    p1 = csp_prefix(csp, a, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
     root = csp_internal_choice(csp, p1, csp->skip);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a->STOP|~|SKIP", root);
@@ -226,9 +210,6 @@ TEST_CASE("parse: a → STOP ⊓ SKIP")
 TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
-    csp_id c;
     csp_id p1;
     csp_id p2;
     csp_id p3;
@@ -236,12 +217,9 @@ TEST_CASE("associativity: a → STOP ⊓ b → STOP ⊓ c → STOP")
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    c = csp_get_event_id("c");
-    p1 = csp_prefix(csp, a, csp->stop);
-    p2 = csp_prefix(csp, b, csp->stop);
-    p3 = csp_prefix(csp, c, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
+    p2 = csp_prefix(csp, csp_event_get("b"), csp->stop);
+    p3 = csp_prefix(csp, csp_event_get("c"), csp->stop);
     p4 = csp_internal_choice(csp, p2, p3);
     root = csp_internal_choice(csp, p1, p4);
     /* Verify that we can parse the process, with and without whitespace. */
@@ -271,12 +249,10 @@ TEST_CASE("parse: (STOP)")
 TEST_CASE("parse: a → STOP")
 {
     struct csp *csp;
-    csp_id a;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    root = csp_prefix(csp, a, csp->stop);
+    root = csp_prefix(csp, csp_event_get("a"), csp->stop);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a->STOP", root);
     check_csp0_eq(" a->STOP", root);
@@ -302,16 +278,12 @@ TEST_CASE("parse: a → STOP")
 TEST_CASE("associativity: a → b → STOP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
     csp_id p;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    p = csp_prefix(csp, b, csp->stop);
-    root = csp_prefix(csp, a, p);
+    p = csp_prefix(csp, csp_event_get("b"), csp->stop);
+    root = csp_prefix(csp, csp_event_get("a"), p);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a -> b -> STOP", root);
     check_csp0_eq("a → b → STOP", root);
@@ -365,13 +337,11 @@ TEST_CASE("parse: let X = a → Y Y = b → X within X")
 TEST_CASE("parse: □ {a → STOP, SKIP}")
 {
     struct csp *csp;
-    csp_id a;
     csp_id p1;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    p1 = csp_prefix(csp, a, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
     root = csp_external_choice(csp, p1, csp->skip);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("[]{a->STOP,SKIP}", root);
@@ -412,13 +382,11 @@ TEST_CASE("parse: □ {a → STOP, SKIP}")
 TEST_CASE("parse: ⊓ {a → STOP, SKIP}")
 {
     struct csp *csp;
-    csp_id a;
     csp_id p1;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    p1 = csp_prefix(csp, a, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
     root = csp_internal_choice(csp, p1, csp->skip);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("|~|{a->STOP,SKIP}", root);
@@ -459,13 +427,11 @@ TEST_CASE("parse: ⊓ {a → STOP, SKIP}")
 TEST_CASE("parse: a → SKIP ; STOP")
 {
     struct csp *csp;
-    csp_id a;
     csp_id p1;
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    p1 = csp_prefix(csp, a, csp->skip);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->skip);
     root = csp_sequential_composition(csp, p1, csp->stop);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("a→SKIP;STOP", root);
@@ -490,9 +456,6 @@ TEST_CASE("parse: a → SKIP ; STOP")
 TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
-    csp_id c;
     csp_id p1;
     csp_id p2;
     csp_id p3;
@@ -500,12 +463,9 @@ TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP")
     csp_id root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    c = csp_get_event_id("c");
-    p1 = csp_prefix(csp, a, csp->skip);
-    p2 = csp_prefix(csp, b, csp->skip);
-    p3 = csp_prefix(csp, c, csp->skip);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->skip);
+    p2 = csp_prefix(csp, csp_event_get("b"), csp->skip);
+    p3 = csp_prefix(csp, csp_event_get("c"), csp->skip);
     p4 = csp_sequential_composition(csp, p2, p3);
     root = csp_sequential_composition(csp, p1, p4);
     /* Verify that we can parse the process, with and without whitespace. */
@@ -517,9 +477,6 @@ TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP")
 TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
-    csp_id c;
     csp_id p1;
     csp_id p2;
     csp_id p3;
@@ -530,12 +487,9 @@ TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP")
     /* Expected result is
      * (a → STOP □ b → STOP) ⊓ (c → STOP)
      */
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    c = csp_get_event_id("c");
-    p1 = csp_prefix(csp, a, csp->stop);
-    p2 = csp_prefix(csp, b, csp->stop);
-    p3 = csp_prefix(csp, c, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
+    p2 = csp_prefix(csp, csp_event_get("b"), csp->stop);
+    p3 = csp_prefix(csp, csp_event_get("c"), csp->stop);
     p4 = csp_external_choice(csp, p1, p2);
     root = csp_internal_choice(csp, p4, p3);
     /* Verify the precedence order of operations. */
@@ -547,9 +501,6 @@ TEST_CASE("precedence: a → STOP □ b → STOP ⊓ c → STOP")
 TEST_CASE("precedence: a → STOP □ b → SKIP ; c → STOP")
 {
     struct csp *csp;
-    csp_id a;
-    csp_id b;
-    csp_id c;
     csp_id p1;
     csp_id p2;
     csp_id p3;
@@ -560,12 +511,9 @@ TEST_CASE("precedence: a → STOP □ b → SKIP ; c → STOP")
     /* Expected result is
      * a → STOP □ (b → SKIP ; c → STOP)
      */
-    a = csp_get_event_id("a");
-    b = csp_get_event_id("b");
-    c = csp_get_event_id("c");
-    p1 = csp_prefix(csp, a, csp->stop);
-    p2 = csp_prefix(csp, b, csp->skip);
-    p3 = csp_prefix(csp, c, csp->stop);
+    p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
+    p2 = csp_prefix(csp, csp_event_get("b"), csp->skip);
+    p3 = csp_prefix(csp, csp_event_get("c"), csp->stop);
     p4 = csp_sequential_composition(csp, p2, p3);
     root = csp_external_choice(csp, p1, p4);
     /* Verify the precedence order of operations. */

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -15,48 +15,54 @@ TEST_CASE_GROUP("environments");
 TEST_CASE("predefined STOP process exists")
 {
     struct csp *csp;
-    struct csp_id_set set;
+    struct csp_event_set initials;
+    struct csp_id_set afters;
     /* Create the CSP environment. */
-    csp_id_set_init(&set);
+    csp_event_set_init(&initials);
+    csp_id_set_init(&afters);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the STOP process. */
-    csp_id_set_clear(&set);
-    csp_build_process_initials(csp, csp->stop, &set);
-    check_set_eq(&set, id_set());
+    csp_event_set_clear(&initials);
+    csp_build_process_initials(csp, csp->stop, &initials);
+    check(csp_event_set_eq(&initials, event_set()));
     /* Verify the afters of τ. */
-    csp_id_set_clear(&set);
-    csp_build_process_afters(csp, csp->stop, csp->tau, &set);
-    check_set_eq(&set, id_set());
+    csp_id_set_clear(&afters);
+    csp_build_process_afters(csp, csp->stop, csp->tau, &afters);
+    check_set_eq(&afters, id_set());
     /* Verify the afters of ✔. */
-    csp_id_set_clear(&set);
-    csp_build_process_afters(csp, csp->stop, csp->tick, &set);
-    check_set_eq(&set, id_set());
+    csp_id_set_clear(&afters);
+    csp_build_process_afters(csp, csp->stop, csp->tick, &afters);
+    check_set_eq(&afters, id_set());
     /* Clean up. */
-    csp_id_set_done(&set);
+    csp_event_set_done(&initials);
+    csp_id_set_done(&afters);
     csp_free(csp);
 }
 
 TEST_CASE("predefined SKIP process exists")
 {
     struct csp *csp;
-    struct csp_id_set set;
+    struct csp_event_set initials;
+    struct csp_id_set afters;
     /* Create the CSP environment. */
-    csp_id_set_init(&set);
+    csp_event_set_init(&initials);
+    csp_id_set_init(&afters);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the SKIP process. */
-    csp_id_set_clear(&set);
-    csp_build_process_initials(csp, csp->skip, &set);
-    check_set_eq(&set, id_set(csp->tick));
+    csp_event_set_clear(&initials);
+    csp_build_process_initials(csp, csp->skip, &initials);
+    check(csp_event_set_eq(&initials, event_set("✔")));
     /* Verify the afters of τ. */
-    csp_id_set_clear(&set);
-    csp_build_process_afters(csp, csp->skip, csp->tau, &set);
-    check_set_eq(&set, id_set());
+    csp_id_set_clear(&afters);
+    csp_build_process_afters(csp, csp->skip, csp->tau, &afters);
+    check_set_eq(&afters, id_set());
     /* Verify the afters of ✔. */
-    csp_id_set_clear(&set);
-    csp_build_process_afters(csp, csp->skip, csp->tick, &set);
-    check_set_eq(&set, id_set(csp->stop));
+    csp_id_set_clear(&afters);
+    csp_build_process_afters(csp, csp->skip, csp->tick, &afters);
+    check_set_eq(&afters, id_set(csp->stop));
     /* Clean up. */
-    csp_id_set_done(&set);
+    csp_event_set_done(&initials);
+    csp_id_set_done(&afters);
     csp_free(csp);
 }
 

--- a/tests/test-event-sets.c
+++ b/tests/test-event-sets.c
@@ -16,50 +16,6 @@ e(const char *name)
     return csp_event_get(name);
 }
 
-static void
-csp_event_set_free_(void *vset)
-{
-    struct csp_event_set *set = vset;
-    csp_event_set_done(set);
-    free(set);
-}
-
-/* Creates a new empty set.  The set will be automatically freed for you at the
- * end of the test case. */
-static struct csp_event_set *
-empty_event_set(void)
-{
-    struct csp_event_set *set = malloc(sizeof(struct csp_event_set));
-    assert(set != NULL);
-    csp_event_set_init(set);
-    test_case_cleanup_register(csp_event_set_free_, set);
-    return set;
-}
-
-/* Creates a new set containing the given events.  The set will be automatically
- * freed for you at the end of the test case. */
-#define event_set(...)                                 \
-    CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
-    (event_set_(LENGTH(__VA_ARGS__), __VA_ARGS__))(empty_event_set())
-
-static struct csp_event_set *
-event_set_(size_t count, ...)
-{
-    size_t i;
-    va_list args;
-    struct csp_event_set *set = malloc(sizeof(struct csp_event_set));
-    assert(set != NULL);
-    csp_event_set_init(set);
-    test_case_cleanup_register(csp_event_set_free_, set);
-    va_start(args, count);
-    for (i = 0; i < count; i++) {
-        const char *name = va_arg(args, const char *);
-        csp_event_set_add(set, e(name));
-    }
-    va_end(args);
-    return set;
-}
-
 TEST_CASE_GROUP("events sets");
 
 TEST_CASE("can create empty set")


### PR DESCRIPTION
Instead of referring to events by their numeric identifier, we now pass around the pointers to the event objects.  We'll have already interned them, so they're just as easy to compare as integers, and they're the
same size.