### PR TITLE
Use process objects in process interface

### DIFF
--- a/src/behavior.c
+++ b/src/behavior.c
@@ -48,10 +48,11 @@ csp_behavior_refines(const struct csp_behavior *spec,
 }
 
 static void
-csp_process_add_traces_behavior(struct csp *csp, csp_id process,
+csp_process_add_traces_behavior(struct csp *csp, struct csp_process *process,
                                 struct csp_behavior *behavior)
 {
-    csp_build_process_initials(csp, process, &behavior->initials);
+    struct csp_collect_events collect = csp_collect_events(&behavior->initials);
+    csp_process_visit_initials(csp, process, &collect.visitor);
 }
 
 static void
@@ -63,7 +64,7 @@ csp_behavior_finish_traces(struct csp *csp, struct csp_behavior *behavior)
 }
 
 static void
-csp_process_get_traces_behavior(struct csp *csp, csp_id process,
+csp_process_get_traces_behavior(struct csp *csp, struct csp_process *process,
                                 struct csp_behavior *behavior)
 {
     csp_event_set_clear(&behavior->initials);
@@ -72,7 +73,7 @@ csp_process_get_traces_behavior(struct csp *csp, csp_id process,
 }
 
 void
-csp_process_get_behavior(struct csp *csp, csp_id process,
+csp_process_get_behavior(struct csp *csp, struct csp_process *process,
                          enum csp_semantic_model model,
                          struct csp_behavior *behavior)
 {
@@ -87,21 +88,21 @@ csp_process_get_behavior(struct csp *csp, csp_id process,
 
 static void
 csp_process_set_get_traces_behavior(struct csp *csp,
-                                    const struct csp_id_set *processes,
+                                    const struct csp_process_set *processes,
                                     struct csp_behavior *behavior)
 {
-    struct csp_id_set_iterator iter;
+    struct csp_process_set_iterator iter;
     csp_event_set_clear(&behavior->initials);
-    csp_id_set_foreach (processes, &iter) {
-        csp_process_add_traces_behavior(csp, csp_id_set_iterator_get(&iter),
-                                        behavior);
+    csp_process_set_foreach (processes, &iter) {
+        struct csp_process *process = csp_process_set_iterator_get(&iter);
+        csp_process_add_traces_behavior(csp, process, behavior);
     }
     csp_behavior_finish_traces(csp, behavior);
 }
 
 void
 csp_process_set_get_behavior(struct csp *csp,
-                             const struct csp_id_set *processes,
+                             const struct csp_process_set *processes,
                              enum csp_semantic_model model,
                              struct csp_behavior *behavior)
 {

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -11,6 +11,7 @@
 #include "basics.h"
 #include "environment.h"
 #include "event.h"
+#include "process.h"
 
 /*------------------------------------------------------------------------------
  * Process behavior
@@ -41,7 +42,7 @@ csp_behavior_refines(const struct csp_behavior *spec,
 /* Fill in `behavior` with the behavior of `process` in the given semantic
  * model.  You must have already initialized `behavior`. */
 void
-csp_process_get_behavior(struct csp *csp, csp_id process,
+csp_process_get_behavior(struct csp *csp, struct csp_process *process,
                          enum csp_semantic_model model,
                          struct csp_behavior *behavior);
 
@@ -49,7 +50,7 @@ csp_process_get_behavior(struct csp *csp, csp_id process,
  * semantic model.  You must have already initialized `behavior`. */
 void
 csp_process_set_get_behavior(struct csp *csp,
-                             const struct csp_id_set *processes,
+                             const struct csp_process_set *processes,
                              enum csp_semantic_model model,
                              struct csp_behavior *behavior);
 

--- a/src/csp0.h
+++ b/src/csp0.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -18,7 +18,7 @@
 /* Load in a CSP₀ process from an in-memory string, placing the ID of the new
  * process in `dest`.  Returns 0 on success.  If the CSP₀ process is invalid,
  * returns -1. */
-int
-csp_load_csp0_string(struct csp *csp, const char *str, csp_id *dest);
+struct csp_process *
+csp_load_csp0_string(struct csp *csp, const char *str);
 
 #endif /* HST_CSP0_H */

--- a/src/environment.h
+++ b/src/environment.h
@@ -30,8 +30,8 @@ typedef uint64_t csp_id;
 struct csp {
     const struct csp_event *tau;
     const struct csp_event *tick;
-    csp_id skip;
-    csp_id stop;
+    struct csp_process *skip;
+    struct csp_process *stop;
 };
 
 struct csp *
@@ -55,15 +55,6 @@ csp_get_process(struct csp *csp, csp_id id);
  * exist. */
 struct csp_process *
 csp_require_process(struct csp *csp, csp_id id);
-
-void
-csp_build_process_initials(struct csp *csp, csp_id process_id,
-                           struct csp_event_set *set);
-
-void
-csp_build_process_afters(struct csp *csp, csp_id process_id,
-                         const struct csp_event *initial,
-                         struct csp_id_set *set);
 
 /*------------------------------------------------------------------------------
  * Constructing process IDs
@@ -128,5 +119,8 @@ csp_id_add_name_sized(csp_id id, const char *name, size_t name_length);
 
 csp_id
 csp_id_add_process(csp_id id, struct csp_process *process);
+
+csp_id
+csp_id_add_process_set(csp_id id, const struct csp_process_set *set);
 
 #endif /* HST_ENVIRONMENT_H */

--- a/src/normalization.c
+++ b/src/normalization.c
@@ -22,21 +22,23 @@
 #if defined(NORMALIZATION_DEBUG)
 #include <stdio.h>
 #define XDEBUG(...) fprintf(stderr, __VA_ARGS__)
-#define XDEBUG_PROCESS_SET(set)                             \
-    do {                                                    \
-        bool __first = true;                                \
-        struct csp_id_set_iterator __iter;                  \
-        XDEBUG("{");                                        \
-        csp_id_set_foreach ((set), &__iter) {               \
-            csp_id __id = csp_id_set_iterator_get(&__iter); \
-            if (__first) {                                  \
-                __first = false;                            \
-            } else {                                        \
-                XDEBUG(",");                                \
-            }                                               \
-            XDEBUG(CSP_ID_FMT, __id);                       \
-        }                                                   \
-        XDEBUG("}");                                        \
+#define XDEBUG_PROCESS_SET(set)                            \
+    do {                                                   \
+        bool __first = true;                               \
+        struct csp_process_set_iterator __iter;            \
+        XDEBUG("{");                                       \
+        csp_process_set_foreach((set), &__iter)            \
+        {                                                  \
+            struct csp_process *__process =                \
+                    csp_process_set_iterator_get(&__iter); \
+            if (__first) {                                 \
+                __first = false;                           \
+            } else {                                       \
+                XDEBUG(",");                               \
+            }                                              \
+            XDEBUG(CSP_ID_FMT, __process->id);             \
+        }                                                  \
+        XDEBUG("}");                                       \
     } while (0)
 #else
 #define XDEBUG(...)             /* do nothing */
@@ -60,34 +62,35 @@
 
 void
 csp_find_process_closure(struct csp *csp, const struct csp_event *event,
-                         struct csp_id_set *processes)
+                         struct csp_process_set *processes)
 {
     bool another_round_needed = true;
-    struct csp_id_set queue1;
-    struct csp_id_set queue2;
-    struct csp_id_set *current_queue = &queue1;
-    struct csp_id_set *next_queue = &queue2;
-    csp_id_set_init(&queue1);
-    csp_id_set_init(&queue2);
-    csp_id_set_union(current_queue, processes);
+    struct csp_process_set queue1;
+    struct csp_process_set queue2;
+    struct csp_process_set *current_queue = &queue1;
+    struct csp_process_set *next_queue = &queue2;
+    csp_process_set_init(&queue1);
+    csp_process_set_init(&queue2);
+    csp_process_set_union(current_queue, processes);
     XDEBUG("=== closure of ");
     DEBUG_PROCESS_SET(processes);
     while (another_round_needed) {
-        struct csp_id_set_iterator i;
+        struct csp_process_set_iterator i;
         DEBUG("--- start closure iteration %p", current_queue);
-        csp_id_set_clear(next_queue);
-        csp_id_set_foreach (current_queue, &i) {
-            csp_id process = csp_id_set_iterator_get(&i);
-            DEBUG("process " CSP_ID_FMT, process);
+        csp_process_set_clear(next_queue);
+        csp_process_set_foreach (current_queue, &i) {
+            struct csp_process *process = csp_process_set_iterator_get(&i);
+            struct csp_collect_afters collect = csp_collect_afters(next_queue);
+            DEBUG("process " CSP_ID_FMT, process->id);
             /* Enqueue each of the states that we can reach from `process` by
              * following a single `event`. */
-            csp_build_process_afters(csp, process, event, next_queue);
+            csp_process_visit_afters(csp, process, event, &collect.visitor);
         }
-        another_round_needed = csp_id_set_union(processes, next_queue);
+        another_round_needed = csp_process_set_union(processes, next_queue);
         swap(current_queue, next_queue);
     }
-    csp_id_set_done(&queue1);
-    csp_id_set_done(&queue2);
+    csp_process_set_done(&queue1);
+    csp_process_set_done(&queue2);
 }
 
 /*------------------------------------------------------------------------------
@@ -103,12 +106,12 @@ static void
 csp_process_get_single_after_visit_edge(struct csp *csp,
                                         struct csp_edge_visitor *visitor,
                                         const struct csp_event *initial,
-                                        csp_id after)
+                                        struct csp_process *after)
 {
     struct csp_process_get_single_after *self =
             container_of(visitor, struct csp_process_get_single_after, visitor);
     assert(self->after == NULL);
-    self->after = csp_require_process(csp, after);
+    self->after = after;
 }
 
 struct csp_process *
@@ -127,12 +130,13 @@ csp_process_get_single_after(struct csp *csp, struct csp_process *process,
 
 struct csp_prenormalized_process {
     struct csp_process process;
-    struct csp_id_set ps; /* Must be τ-closed */
+    struct csp_process_set ps; /* Must be τ-closed */
 };
 
 /* `ps` must be τ-closed */
 struct csp_process *
-csp_prenormalized_process_new(struct csp *csp, const struct csp_id_set *ps);
+csp_prenormalized_process_new(struct csp *csp,
+                              const struct csp_process_set *ps);
 
 static void
 csp_prenormalized_process_initials(struct csp *csp, struct csp_process *process,
@@ -143,11 +147,9 @@ csp_prenormalized_process_initials(struct csp *csp, struct csp_process *process,
     struct csp_prenormalized_process *self =
             container_of(process, struct csp_prenormalized_process, process);
     struct csp_ignore_event ignore = csp_ignore_event(visitor, csp->tau);
-    struct csp_id_set_iterator iter;
-    csp_id_set_foreach (&self->ps, &iter) {
-        csp_id subprocess_id = csp_id_set_iterator_get(&iter);
-        struct csp_process *subprocess =
-                csp_require_process(csp, subprocess_id);
+    struct csp_process_set_iterator iter;
+    csp_process_set_foreach (&self->ps, &iter) {
+        struct csp_process *subprocess = csp_process_set_iterator_get(&iter);
         csp_process_visit_initials(csp, subprocess, &ignore.visitor);
     }
 }
@@ -159,8 +161,8 @@ csp_prenormalized_process_afters(struct csp *csp, struct csp_process *process,
 {
     struct csp_prenormalized_process *self =
             container_of(process, struct csp_prenormalized_process, process);
-    struct csp_id_set afters;
-    struct csp_id_set_iterator iter;
+    struct csp_process_set afters;
+    struct csp_process_set_iterator iter;
     struct csp_process *after;
 
     /* Normalized processes can never perform a τ. */
@@ -170,18 +172,19 @@ csp_prenormalized_process_afters(struct csp *csp, struct csp_process *process,
 
     /* Find the set of processes that you could end up in by starting in one of
      * our underlying processes and following a single `initial` event. */
-    csp_id_set_init(&afters);
-    csp_id_set_foreach (&self->ps, &iter) {
-        csp_id subprocess_id = csp_id_set_iterator_get(&iter);
-        csp_build_process_afters(csp, subprocess_id, initial, &afters);
+    csp_process_set_init(&afters);
+    csp_process_set_foreach (&self->ps, &iter) {
+        struct csp_process *subprocess = csp_process_set_iterator_get(&iter);
+        struct csp_collect_afters collect = csp_collect_afters(&afters);
+        csp_process_visit_afters(csp, subprocess, initial, &collect.visitor);
     }
 
     /* Since a normalized process can only have one `after` for any event, merge
      * together all of the possible afters into a single normalized process. */
     csp_find_process_closure(csp, csp->tau, &afters);
     after = csp_prenormalized_process_new(csp, &afters);
-    csp_id_set_done(&afters);
-    csp_edge_visitor_call(csp, visitor, initial, after->id);
+    csp_process_set_done(&afters);
+    csp_edge_visitor_call(csp, visitor, initial, after);
 }
 
 static void
@@ -189,7 +192,7 @@ csp_prenormalized_process_free(struct csp *csp, struct csp_process *process)
 {
     struct csp_prenormalized_process *self =
             container_of(process, struct csp_prenormalized_process, process);
-    csp_id_set_done(&self->ps);
+    csp_process_set_done(&self->ps);
     free(self);
 }
 
@@ -198,16 +201,16 @@ static const struct csp_process_iface csp_prenormalized_process_iface = {
         csp_prenormalized_process_free};
 
 static csp_id
-csp_prenormalized_process_get_id(const struct csp_id_set *ps)
+csp_prenormalized_process_get_id(const struct csp_process_set *ps)
 {
     static struct csp_id_scope prenormalized_process;
     csp_id id = csp_id_start(&prenormalized_process);
-    id = csp_id_add_id_set(id, ps);
+    id = csp_id_add_process_set(id, ps);
     return id;
 }
 
 struct csp_process *
-csp_prenormalized_process_new(struct csp *csp, const struct csp_id_set *ps)
+csp_prenormalized_process_new(struct csp *csp, const struct csp_process_set *ps)
 {
     struct csp_prenormalized_process *self;
     csp_id id = csp_prenormalized_process_get_id(ps);
@@ -216,8 +219,8 @@ csp_prenormalized_process_new(struct csp *csp, const struct csp_id_set *ps)
     assert(self != NULL);
     self->process.id = id;
     self->process.iface = &csp_prenormalized_process_iface;
-    csp_id_set_init(&self->ps);
-    csp_id_set_union(&self->ps, ps);
+    csp_process_set_init(&self->ps);
+    csp_process_set_union(&self->ps, ps);
     csp_register_process(csp, &self->process);
     return &self->process;
 }
@@ -225,13 +228,13 @@ csp_prenormalized_process_new(struct csp *csp, const struct csp_id_set *ps)
 struct csp_process *
 csp_prenormalize_process(struct csp *csp, struct csp_process *subprocess)
 {
-    struct csp_id_set ps;
+    struct csp_process_set ps;
     struct csp_process *process;
-    csp_id_set_init(&ps);
-    csp_id_set_add(&ps, subprocess->id);
+    csp_process_set_init(&ps);
+    csp_process_set_add(&ps, subprocess);
     csp_find_process_closure(csp, csp->tau, &ps);
     process = csp_prenormalized_process_new(csp, &ps);
-    csp_id_set_done(&ps);
+    csp_process_set_done(&ps);
     return process;
 }
 
@@ -242,7 +245,7 @@ csp_prenormalized_process_downcast(struct csp_process *process)
     return container_of(process, struct csp_prenormalized_process, process);
 }
 
-const struct csp_id_set *
+const struct csp_process_set *
 csp_prenormalized_process_get_processes(struct csp_process *process)
 {
     struct csp_prenormalized_process *self =
@@ -283,11 +286,11 @@ csp_equivalences_equiv(struct csp_equivalences *equiv, struct csp_process *p1,
 static void
 csp_processes_equiv_visit_edge(struct csp *csp,
                                struct csp_edge_visitor *visitor,
-                               const struct csp_event *event, csp_id after1_id)
+                               const struct csp_event *event,
+                               struct csp_process *after1)
 {
     struct csp_processes_equiv *self = container_of(
             visitor, struct csp_processes_equiv, visitor);
-    struct csp_process *after1 = csp_require_process(csp, after1_id);
     struct csp_process *after2 =
             csp_process_get_single_after(csp, self->p2, event);
     assert(after2 != NULL);
@@ -338,7 +341,7 @@ csp_init_bisimulation_visit_process(struct csp *csp,
      * equivalent. */
     struct csp_init_bisimulation *self = container_of(
             visitor, struct csp_init_bisimulation, visitor);
-    csp_process_get_behavior(csp, process->id, CSP_TRACES, &self->behavior);
+    csp_process_get_behavior(csp, process, CSP_TRACES, &self->behavior);
     DEBUG("  init " CSP_ID_FMT " ⇒ " CSP_ID_FMT, process->id,
           self->behavior.hash);
     csp_equivalences_add(self->equiv, self->behavior.hash, process->id);
@@ -457,7 +460,7 @@ csp_calculate_bisimulation(struct csp *csp, struct csp_process *prenormalized,
 struct csp_normalized_process {
     struct csp_process process;
     struct csp_process *prenormalized_root;
-    struct csp_id_set ps; /* Should contain prenormalized processes */
+    struct csp_id_set subprocess_ids; /* Should be prenormalized processes */
     struct csp_equivalences *equiv;
     csp_id equivalence_class;
     bool equiv_owned;
@@ -477,7 +480,7 @@ csp_normalized_process_initials(struct csp *csp, struct csp_process *process,
             container_of(process, struct csp_normalized_process, process);
     struct csp_ignore_event ignore = csp_ignore_event(visitor, csp->tau);
     struct csp_id_set_iterator iter;
-    csp_id_set_foreach (&self->ps, &iter) {
+    csp_id_set_foreach (&self->subprocess_ids, &iter) {
         csp_id subprocess_id = csp_id_set_iterator_get(&iter);
         struct csp_process *subprocess =
                 csp_require_process(csp, subprocess_id);
@@ -492,20 +495,20 @@ csp_normalized_process_afters(struct csp *csp, struct csp_process *process,
 {
     struct csp_normalized_process *self =
             container_of(process, struct csp_normalized_process, process);
-    struct csp_id_set_iterator iter;
-    struct csp_id_set afters;
-    struct csp_collect_afters collect;
+    struct csp_id_set_iterator i;
+    struct csp_process_set_iterator p;
+    struct csp_process_set afters;
     csp_id equivalence_class;
     struct csp_process *after;
 
     /* Find the set of processes that you could end up in by starting in one of
      * our underlying processes and following a single `initial` event. */
-    csp_id_set_init(&afters);
-    collect = csp_collect_afters(&afters);
-    csp_id_set_foreach (&self->ps, &iter) {
-        csp_id subprocess_id = csp_id_set_iterator_get(&iter);
+    csp_process_set_init(&afters);
+    csp_id_set_foreach (&self->subprocess_ids, &i) {
+        csp_id subprocess_id = csp_id_set_iterator_get(&i);
         struct csp_process *subprocess =
                 csp_require_process(csp, subprocess_id);
+        struct csp_collect_afters collect = csp_collect_afters(&afters);
         csp_process_visit_afters(csp, subprocess, initial, &collect.visitor);
     }
 
@@ -513,21 +516,21 @@ csp_normalized_process_afters(struct csp *csp, struct csp_process *process,
      * equivalent processes via bisimulation, all of the `afters` that we just
      * found should all belong to the same equivalence class. */
     equivalence_class = CSP_ID_NONE;
-    csp_id_set_foreach (&afters, &iter) {
-        csp_id after_id = csp_id_set_iterator_get(&iter);
+    csp_process_set_foreach (&afters, &p) {
+        struct csp_process *after = csp_process_set_iterator_get(&p);
         csp_id after_equivalence_class =
-                csp_equivalences_get_class(self->equiv, after_id);
+                csp_equivalences_get_class(self->equiv, after->id);
         assert(equivalence_class == CSP_ID_NONE ||
                equivalence_class == after_equivalence_class);
         equivalence_class = after_equivalence_class;
     }
-    csp_id_set_done(&afters);
+    csp_process_set_done(&afters);
 
     /* Our "real" after is the normalized node for this equivalence class that
      * we just found. */
     after = csp_normalized_process_new(csp, self->prenormalized_root,
                                        self->equiv, equivalence_class, false);
-    return csp_edge_visitor_call(csp, visitor, initial, after->id);
+    return csp_edge_visitor_call(csp, visitor, initial, after);
 }
 
 static void
@@ -535,7 +538,7 @@ csp_normalized_process_free(struct csp *csp, struct csp_process *process)
 {
     struct csp_normalized_process *self =
             container_of(process, struct csp_normalized_process, process);
-    csp_id_set_done(&self->ps);
+    csp_id_set_done(&self->subprocess_ids);
     if (self->equiv_owned) {
         csp_equivalences_free(self->equiv);
     }
@@ -583,8 +586,9 @@ csp_normalized_process_new(struct csp *csp,
     self->equiv = equiv;
     self->equiv_owned = equiv_owned;
     self->equivalence_class = equivalence_class;
-    csp_id_set_init(&self->ps);
-    csp_equivalences_build_members(equiv, equivalence_class, &self->ps);
+    csp_id_set_init(&self->subprocess_ids);
+    csp_equivalences_build_members(equiv, equivalence_class,
+                                   &self->subprocess_ids);
     csp_register_process(csp, &self->process);
     return &self->process;
 }
@@ -625,7 +629,7 @@ csp_normalized_subprocess(struct csp *csp, struct csp_process *root_,
 void
 csp_normalized_process_get_processes(struct csp *csp,
                                      struct csp_process *process,
-                                     struct csp_id_set *set)
+                                     struct csp_process_set *set)
 {
     struct csp_id_set_iterator iter;
     struct csp_normalized_process *self =
@@ -633,11 +637,11 @@ csp_normalized_process_get_processes(struct csp *csp,
     /* self->ps is the set of prenormalized processes that this normalized
      * process represents.  We need to grab the processes that each of those
      * represent to get our final answer. */
-    csp_id_set_foreach (&self->ps, &iter) {
-        csp_id prenormalized_id = csp_id_set_iterator_get(&iter);
-        struct csp_process *prenormalized =
-                csp_require_process(csp, prenormalized_id);
-        csp_id_set_union(
-                set, csp_prenormalized_process_get_processes(prenormalized));
+    csp_id_set_foreach (&self->subprocess_ids, &iter) {
+        csp_id subprocess_id = csp_id_set_iterator_get(&iter);
+        struct csp_process *subprocess =
+                csp_require_process(csp, subprocess_id);
+        csp_process_set_union(
+                set, csp_prenormalized_process_get_processes(subprocess));
     }
 }

--- a/src/normalization.h
+++ b/src/normalization.h
@@ -12,7 +12,6 @@
 #include "environment.h"
 #include "equivalence.h"
 #include "event.h"
-#include "id-set.h"
 #include "process.h"
 
 /*------------------------------------------------------------------------------
@@ -42,10 +41,10 @@ csp_normalize_process(struct csp *csp, struct csp_process *prenormalized);
  * τ-closed. */
 struct csp_process *
 csp_prenormalized_process_new(struct csp *csp,
-                              const struct csp_id_set *processes);
+                              const struct csp_process_set *processes);
 
 /* Returns the set of processes that a prenormalized node represents. */
-const struct csp_id_set *
+const struct csp_process_set *
 csp_prenormalized_process_get_processes(struct csp_process *process);
 
 /* Finds the subprocess of a `normalized` process that corresponds to a
@@ -59,7 +58,7 @@ csp_normalized_subprocess(struct csp *csp, struct csp_process *normalized,
 void
 csp_normalized_process_get_processes(struct csp *csp,
                                      struct csp_process *process,
-                                     struct csp_id_set *set);
+                                     struct csp_process_set *set);
 
 /* Returns the single `after` process for a particular `initial`, or NULL if
  * there is none.  If `process` has multiple `afters` for `initial`, the result
@@ -79,7 +78,7 @@ csp_process_get_single_after(struct csp *csp, struct csp_process *process,
  * must always include the initial processes). */
 void
 csp_find_process_closure(struct csp *csp, const struct csp_event *event,
-                         struct csp_id_set *processes);
+                         struct csp_process_set *processes);
 
 /* Bisimulate all of the nodes in a prenormalized process, to find nodes that
  * have equivalent behavior.  Each prenormalized subprocess reachable from

--- a/src/operators.h
+++ b/src/operators.h
@@ -22,23 +22,28 @@
 /* In all of the below:  `p` and `q` are processes.  `ps` is a set of processes.
  * `a` is an event. */
 
-csp_id
-csp_external_choice(struct csp *csp, csp_id p, csp_id q);
+struct csp_process *
+csp_external_choice(struct csp *csp, struct csp_process *p,
+                    struct csp_process *q);
 
-csp_id
-csp_internal_choice(struct csp *csp, csp_id p, csp_id q);
+struct csp_process *
+csp_internal_choice(struct csp *csp, struct csp_process *p,
+                    struct csp_process *q);
 
-csp_id
-csp_prefix(struct csp *csp, const struct csp_event *a, csp_id p);
+struct csp_process *
+csp_prefix(struct csp *csp, const struct csp_event *a, struct csp_process *p);
 
-csp_id
-csp_replicated_external_choice(struct csp *csp, const struct csp_id_set *ps);
+struct csp_process *
+csp_replicated_external_choice(struct csp *csp,
+                               const struct csp_process_set *ps);
 
-csp_id
-csp_replicated_internal_choice(struct csp *csp, const struct csp_id_set *ps);
+struct csp_process *
+csp_replicated_internal_choice(struct csp *csp,
+                               const struct csp_process_set *ps);
 
-csp_id
-csp_sequential_composition(struct csp *csp, csp_id p, csp_id q);
+struct csp_process *
+csp_sequential_composition(struct csp *csp, struct csp_process *p,
+                           struct csp_process *q);
 
 /*------------------------------------------------------------------------------
  * Recursion
@@ -72,16 +77,16 @@ csp_recursion_scope_init(struct csp *csp, struct csp_recursion_scope *scope);
 void
 csp_recursion_scope_done(struct csp_recursion_scope *scope);
 
-/* Return the process ID of the recursion target with the given name, creating
- * it if necessary.  The recursion target will initially be empty; you must
- * "fill" it by calling csp_recursion_scope_fill before destroying the scope. */
-csp_id
+/* Return the recursion target process with the given name, creating it if
+ * necessary.  The recursion target will initially be empty; you must "fill" it
+ * by calling csp_recursion_scope_fill before destroying the scope. */
+struct csp_process *
 csp_recursion_scope_get(struct csp *csp, struct csp_recursion_scope *scope,
                         const char *name);
 
 /* Same as csp_recursion_scope_add, but providing an explicit length for `name`.
  * `name` does not need to be NUL-terminated, but it cannot contain any NULs. */
-csp_id
+struct csp_process *
 csp_recursion_scope_get_sized(struct csp *csp,
                               struct csp_recursion_scope *scope,
                               const char *name, size_t name_length);
@@ -92,7 +97,7 @@ csp_recursion_scope_get_sized(struct csp *csp,
  * recursion target will behave exactly like `process`. */
 bool
 csp_recursion_scope_fill(struct csp_recursion_scope *scope, const char *name,
-                         csp_id process);
+                         struct csp_process *process);
 
 /* Same as csp_recursion_scope_fill, but providing an explicit length for
  * `name`.  `name` does not need to be NUL-terminated, but it cannot contain any
@@ -100,6 +105,6 @@ csp_recursion_scope_fill(struct csp_recursion_scope *scope, const char *name,
 bool
 csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
                                const char *name, size_t name_length,
-                               csp_id process);
+                               struct csp_process *process);
 
 #endif /* HST_OPERATORS_H */

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -20,7 +20,7 @@
 struct csp_prefix {
     struct csp_process process;
     const struct csp_event *a;
-    csp_id p;
+    struct csp_process *p;
 };
 
 /* Operational semantics for a → P
@@ -64,17 +64,18 @@ static const struct csp_process_iface csp_prefix_iface = {
         csp_prefix_initials, csp_prefix_afters, csp_prefix_free};
 
 static csp_id
-csp_prefix_get_id(const struct csp_event *a, csp_id p)
+csp_prefix_get_id(const struct csp_event *a, struct csp_process *p)
 {
     static struct csp_id_scope prefix;
     csp_id id = csp_id_start(&prefix);
     id = csp_id_add_event(id, a);
-    id = csp_id_add_id(id, p);
+    id = csp_id_add_process(id, p);
     return id;
 }
 
 static struct csp_process *
-csp_prefix_new(struct csp *csp, const struct csp_event *a, csp_id p)
+csp_prefix_new(struct csp *csp, const struct csp_event *a,
+               struct csp_process *p)
 {
     csp_id id = csp_prefix_get_id(a, p);
     struct csp_prefix *prefix;
@@ -89,8 +90,8 @@ csp_prefix_new(struct csp *csp, const struct csp_event *a, csp_id p)
     return &prefix->process;
 }
 
-csp_id
-csp_prefix(struct csp *csp, const struct csp_event *a, csp_id p)
+struct csp_process *
+csp_prefix(struct csp *csp, const struct csp_event *a, struct csp_process *p)
 {
-    return csp_prefix_new(csp, a, p)->id;
+    return csp_prefix_new(csp, a, p);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -10,7 +10,6 @@
 
 #include "basics.h"
 #include "event.h"
-#include "id-set.h"
 
 struct csp;
 struct csp_process;
@@ -52,20 +51,20 @@ csp_ignore_event(struct csp_event_visitor *wrapped,
 
 struct csp_edge_visitor {
     void (*visit)(struct csp *csp, struct csp_edge_visitor *visitor,
-                  const struct csp_event *event, csp_id after);
+                  const struct csp_event *event, struct csp_process *after);
 };
 
 void
 csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
-                      const struct csp_event *event, csp_id after);
+                      const struct csp_event *event, struct csp_process *after);
 
 struct csp_collect_afters {
     struct csp_edge_visitor visitor;
-    struct csp_id_set *set;
+    struct csp_process_set *set;
 };
 
 struct csp_collect_afters
-csp_collect_afters(struct csp_id_set *set);
+csp_collect_afters(struct csp_process_set *set);
 
 /*------------------------------------------------------------------------------
  * Process visitors
@@ -82,11 +81,11 @@ csp_process_visitor_call(struct csp *csp, struct csp_process_visitor *visitor,
 
 struct csp_collect_processes {
     struct csp_process_visitor visitor;
-    struct csp_id_set *set;
+    struct csp_process_set *set;
 };
 
 struct csp_collect_processes
-csp_collect_processes(struct csp_id_set *set);
+csp_collect_processes(struct csp_process_set *set);
 
 /*------------------------------------------------------------------------------
  * Processes

--- a/tests/test-environment.c
+++ b/tests/test-environment.c
@@ -7,6 +7,8 @@
 
 #include "environment.h"
 
+#include "event.h"
+#include "process.h"
 #include "test-case-harness.h"
 #include "test-cases.h"
 
@@ -16,26 +18,29 @@ TEST_CASE("predefined STOP process exists")
 {
     struct csp *csp;
     struct csp_event_set initials;
-    struct csp_id_set afters;
+    struct csp_collect_events collect_initials = csp_collect_events(&initials);
+    struct csp_process_set afters;
+    struct csp_collect_afters collect_afters = csp_collect_afters(&afters);
     /* Create the CSP environment. */
     csp_event_set_init(&initials);
-    csp_id_set_init(&afters);
+    csp_process_set_init(&afters);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the STOP process. */
     csp_event_set_clear(&initials);
-    csp_build_process_initials(csp, csp->stop, &initials);
+    csp_process_visit_initials(csp, csp->stop, &collect_initials.visitor);
     check(csp_event_set_eq(&initials, event_set()));
     /* Verify the afters of τ. */
-    csp_id_set_clear(&afters);
-    csp_build_process_afters(csp, csp->stop, csp->tau, &afters);
-    check_set_eq(&afters, id_set());
+    csp_process_set_clear(&afters);
+    csp_process_visit_afters(csp, csp->stop, csp->tau, &collect_afters.visitor);
+    check(csp_process_set_eq(&afters, process_set()));
     /* Verify the afters of ✔. */
-    csp_id_set_clear(&afters);
-    csp_build_process_afters(csp, csp->stop, csp->tick, &afters);
-    check_set_eq(&afters, id_set());
+    csp_process_set_clear(&afters);
+    csp_process_visit_afters(csp, csp->stop, csp->tick,
+                             &collect_afters.visitor);
+    check(csp_process_set_eq(&afters, process_set()));
     /* Clean up. */
     csp_event_set_done(&initials);
-    csp_id_set_done(&afters);
+    csp_process_set_done(&afters);
     csp_free(csp);
 }
 
@@ -43,26 +48,29 @@ TEST_CASE("predefined SKIP process exists")
 {
     struct csp *csp;
     struct csp_event_set initials;
-    struct csp_id_set afters;
+    struct csp_collect_events collect = csp_collect_events(&initials);
+    struct csp_process_set afters;
+    struct csp_collect_afters collect_afters = csp_collect_afters(&afters);
     /* Create the CSP environment. */
     csp_event_set_init(&initials);
-    csp_id_set_init(&afters);
+    csp_process_set_init(&afters);
     check_alloc(csp, csp_new());
     /* Verify the initials set of the SKIP process. */
     csp_event_set_clear(&initials);
-    csp_build_process_initials(csp, csp->skip, &initials);
+    csp_process_visit_initials(csp, csp->skip, &collect.visitor);
     check(csp_event_set_eq(&initials, event_set("✔")));
     /* Verify the afters of τ. */
-    csp_id_set_clear(&afters);
-    csp_build_process_afters(csp, csp->skip, csp->tau, &afters);
-    check_set_eq(&afters, id_set());
+    csp_process_set_clear(&afters);
+    csp_process_visit_afters(csp, csp->skip, csp->tau, &collect_afters.visitor);
+    check(csp_process_set_eq(&afters, process_set()));
     /* Verify the afters of ✔. */
-    csp_id_set_clear(&afters);
-    csp_build_process_afters(csp, csp->skip, csp->tick, &afters);
-    check_set_eq(&afters, id_set(csp->stop));
+    csp_process_set_clear(&afters);
+    csp_process_visit_afters(csp, csp->skip, csp->tick,
+                             &collect_afters.visitor);
+    check(csp_process_set_eq(&afters, process_set(csp->stop)));
     /* Clean up. */
     csp_event_set_done(&initials);
-    csp_id_set_done(&afters);
+    csp_process_set_done(&afters);
     csp_free(csp);
 }
 

--- a/tests/test-process-sets.c
+++ b/tests/test-process-sets.c
@@ -15,50 +15,6 @@ static struct csp_process p2;
 static struct csp_process p5;
 static struct csp_process p6;
 
-static void
-csp_process_set_free_(void *vset)
-{
-    struct csp_process_set *set = vset;
-    csp_process_set_done(set);
-    free(set);
-}
-
-/* Creates a new empty set.  The set will be automatically freed for you at the
- * end of the test case. */
-static struct csp_process_set *
-empty_process_set(void)
-{
-    struct csp_process_set *set = malloc(sizeof(struct csp_process_set));
-    assert(set != NULL);
-    csp_process_set_init(set);
-    test_case_cleanup_register(csp_process_set_free_, set);
-    return set;
-}
-
-/* Creates a new set containing the given processes.  The set will be
- * automatically freed for you at the end of the test case. */
-#define process_set(...)                                 \
-    CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
-    (process_set_(LENGTH(__VA_ARGS__), __VA_ARGS__))(empty_process_set())
-
-static struct csp_process_set *
-process_set_(size_t count, ...)
-{
-    size_t i;
-    va_list args;
-    struct csp_process_set *set = malloc(sizeof(struct csp_process_set));
-    assert(set != NULL);
-    csp_process_set_init(set);
-    test_case_cleanup_register(csp_process_set_free_, set);
-    va_start(args, count);
-    for (i = 0; i < count; i++) {
-        struct csp_process *process = va_arg(args, struct csp_process *);
-        csp_process_set_add(set, process);
-    }
-    va_end(args);
-    return set;
-}
-
 TEST_CASE_GROUP("process sets");
 
 TEST_CASE("can create empty set")


### PR DESCRIPTION
Just like we just did with event objects.  This should remove all uses of the old ID set, I think, since we now have event- and process-specific sets that we can use instead.