### PR TITLE
Keep track of process names

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,6 +32,7 @@ ForEachMacros:
   - csp_id_set_map_foreach
   - csp_map_foreach
   - csp_normalized_lts_nodes_foreach
+  - csp_process_set_foreach
   - csp_set_foreach
 IncludeCategories:
   - Regex:    '^<.*\.h>'

--- a/src/normalization.c
+++ b/src/normalization.c
@@ -139,6 +139,16 @@ csp_prenormalized_process_new(struct csp *csp,
                               const struct csp_process_set *ps);
 
 static void
+csp_prenormalized_process_name(struct csp *csp, struct csp_process *process,
+                               struct csp_name_visitor *visitor)
+{
+    struct csp_prenormalized_process *self =
+            container_of(process, struct csp_prenormalized_process, process);
+    csp_name_visitor_call(csp, visitor, "prenormalized ");
+    csp_process_set_name(csp, &self->ps, visitor);
+}
+
+static void
 csp_prenormalized_process_initials(struct csp *csp, struct csp_process *process,
                                    struct csp_event_visitor *visitor)
 {
@@ -197,8 +207,8 @@ csp_prenormalized_process_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_prenormalized_process_iface = {
-        csp_prenormalized_process_initials, csp_prenormalized_process_afters,
-        csp_prenormalized_process_free};
+        0, csp_prenormalized_process_name, csp_prenormalized_process_initials,
+        csp_prenormalized_process_afters, csp_prenormalized_process_free};
 
 static csp_id
 csp_prenormalized_process_get_id(const struct csp_process_set *ps)
@@ -473,6 +483,23 @@ csp_normalized_process_new(struct csp *csp,
                            csp_id equivalence_class, bool equiv_owned);
 
 static void
+csp_normalized_process_name(struct csp *csp, struct csp_process *process,
+                            struct csp_name_visitor *visitor)
+{
+    struct csp_normalized_process *self =
+            container_of(process, struct csp_normalized_process, process);
+    struct csp_process_set merged;
+    csp_name_visitor_call(csp, visitor, "normalized ");
+    csp_process_set_init(&merged);
+    csp_normalized_process_get_processes(csp, process, &merged);
+    csp_process_set_name(csp, &merged, visitor);
+    csp_process_set_done(&merged);
+    csp_name_visitor_call(csp, visitor, " within ");
+    csp_process_set_name(csp, csp_prenormalized_process_get_processes(
+                                      self->prenormalized_root), visitor);
+}
+
+static void
 csp_normalized_process_initials(struct csp *csp, struct csp_process *process,
                                 struct csp_event_visitor *visitor)
 {
@@ -546,8 +573,8 @@ csp_normalized_process_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_normalized_process_iface = {
-        csp_normalized_process_initials, csp_normalized_process_afters,
-        csp_normalized_process_free};
+        0, csp_normalized_process_name, csp_normalized_process_initials,
+        csp_normalized_process_afters, csp_normalized_process_free};
 
 static csp_id
 csp_normalized_process_get_id(struct csp_process *prenormalized_root,

--- a/src/operators/external-choice.c
+++ b/src/operators/external-choice.c
@@ -34,6 +34,15 @@ struct csp_external_choice {
  */
 
 static void
+csp_external_choice_name(struct csp *csp, struct csp_process *process,
+                         struct csp_name_visitor *visitor)
+{
+    struct csp_external_choice *choice =
+            container_of(process, struct csp_external_choice, process);
+    csp_process_set_nested_name(csp, process, &choice->ps, "□", visitor);
+}
+
+static void
 csp_external_choice_initials(struct csp *csp, struct csp_process *process,
                              struct csp_event_visitor *visitor)
 {
@@ -127,8 +136,8 @@ csp_external_choice_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_external_choice_iface = {
-        csp_external_choice_initials, csp_external_choice_afters,
-        csp_external_choice_free};
+        6, csp_external_choice_name, csp_external_choice_initials,
+        csp_external_choice_afters, csp_external_choice_free};
 
 static csp_id
 csp_external_choice_get_id(const struct csp_process_set *ps)

--- a/src/operators/internal-choice.c
+++ b/src/operators/internal-choice.c
@@ -29,6 +29,15 @@ struct csp_internal_choice {
  */
 
 static void
+csp_internal_choice_name(struct csp *csp, struct csp_process *process,
+                         struct csp_name_visitor *visitor)
+{
+    struct csp_internal_choice *choice =
+            container_of(process, struct csp_internal_choice, process);
+    csp_process_set_nested_name(csp, process, &choice->ps, "⊓", visitor);
+}
+
+static void
 csp_internal_choice_initials(struct csp *csp, struct csp_process *process,
                              struct csp_event_visitor *visitor)
 {
@@ -63,8 +72,8 @@ csp_internal_choice_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_internal_choice_iface = {
-        csp_internal_choice_initials, csp_internal_choice_afters,
-        csp_internal_choice_free};
+        7, csp_internal_choice_name, csp_internal_choice_initials,
+        csp_internal_choice_afters, csp_internal_choice_free};
 
 static csp_id
 csp_internal_choice_get_id(const struct csp_process_set *ps)

--- a/src/operators/prefix.c
+++ b/src/operators/prefix.c
@@ -30,6 +30,17 @@ struct csp_prefix {
  */
 
 static void
+csp_prefix_name(struct csp *csp, struct csp_process *process,
+                struct csp_name_visitor *visitor)
+{
+    struct csp_prefix *prefix =
+            container_of(process, struct csp_prefix, process);
+    csp_name_visitor_call(csp, visitor, csp_event_name(prefix->a));
+    csp_name_visitor_call(csp, visitor, " → ");
+    csp_process_nested_name(csp, process, prefix->p, visitor);
+}
+
+static void
 csp_prefix_initials(struct csp *csp, struct csp_process *process,
                     struct csp_event_visitor *visitor)
 {
@@ -61,7 +72,8 @@ csp_prefix_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_prefix_iface = {
-        csp_prefix_initials, csp_prefix_afters, csp_prefix_free};
+        1, csp_prefix_name, csp_prefix_initials, csp_prefix_afters,
+        csp_prefix_free};
 
 static csp_id
 csp_prefix_get_id(const struct csp_event *a, struct csp_process *p)

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -35,6 +35,13 @@ struct csp_recursive_process {
 };
 
 static void
+csp_recursive_process_name(struct csp *csp, struct csp_process *process,
+                           struct csp_name_visitor *visitor)
+{
+    csp_name_visitor_call(csp, visitor, "sad face");
+}
+
+static void
 csp_recursive_process_initials(struct csp *csp, struct csp_process *process,
                                struct csp_event_visitor *visitor)
 {
@@ -65,8 +72,8 @@ csp_recursive_process_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_recursive_process_iface = {
-        csp_recursive_process_initials, csp_recursive_process_afters,
-        csp_recursive_process_free};
+        0, csp_recursive_process_name, csp_recursive_process_initials,
+        csp_recursive_process_afters, csp_recursive_process_free};
 
 static struct csp_process *
 csp_recursive_process_new(struct csp *csp, csp_id id)

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -31,15 +31,13 @@
 
 struct csp_recursive_process {
     struct csp_process process;
+    const char *name;
     struct csp_process *definition;
 };
 
 static void
 csp_recursive_process_name(struct csp *csp, struct csp_process *process,
-                           struct csp_name_visitor *visitor)
-{
-    csp_name_visitor_call(csp, visitor, "sad face");
-}
+                           struct csp_name_visitor *visitor);
 
 static void
 csp_recursive_process_initials(struct csp *csp, struct csp_process *process,
@@ -68,6 +66,7 @@ csp_recursive_process_free(struct csp *csp, struct csp_process *process)
 {
     struct csp_recursive_process *recursive_process =
             container_of(process, struct csp_recursive_process, process);
+    free((char *) recursive_process->name);
     free(recursive_process);
 }
 
@@ -76,24 +75,33 @@ static const struct csp_process_iface csp_recursive_process_iface = {
         csp_recursive_process_afters, csp_recursive_process_free};
 
 static struct csp_process *
-csp_recursive_process_new(struct csp *csp, csp_id id)
+csp_recursive_process_new(struct csp *csp, const char *name, size_t name_length,
+                          csp_id id)
 {
     struct csp_recursive_process *recursive_process;
+    char *name_copy;
     return_if_nonnull(csp_get_process(csp, id));
     recursive_process = malloc(sizeof(struct csp_recursive_process));
     assert(recursive_process != NULL);
     recursive_process->process.id = id;
     recursive_process->process.iface = &csp_recursive_process_iface;
+    name_copy = malloc(name_length + 1);
+    assert(name_copy != NULL);
+    memcpy(name_copy, name, name_length);
+    name_copy[name_length] = '\0';
+    recursive_process->name = name_copy;
     recursive_process->definition = NULL;
     csp_register_process(csp, &recursive_process->process);
     return &recursive_process->process;
 }
 
 static void
-csp_recursive_process(struct csp *csp, csp_id id,
+csp_recursive_process(struct csp *csp, const char *name, size_t name_length,
+                      csp_id id,
                       struct csp_recursive_process **recursive_process)
 {
-    struct csp_process *process = csp_recursive_process_new(csp, id);
+    struct csp_process *process =
+            csp_recursive_process_new(csp, name, name_length, id);
     *recursive_process =
             container_of(process, struct csp_recursive_process, process);
 }
@@ -179,7 +187,7 @@ csp_recursion_scope_get_sized(struct csp *csp,
     csp_id id = csp_recursion_create_id(scope->scope, name, name_length);
     recursive_process = csp_recursive_processes_at(&scope->processes, id);
     if (*recursive_process == NULL) {
-        csp_recursive_process(csp, id, recursive_process);
+        csp_recursive_process(csp, name, name_length, id, recursive_process);
         scope->unfilled_count++;
     }
     return &(*recursive_process)->process;
@@ -211,4 +219,100 @@ csp_recursion_scope_fill_sized(struct csp_recursion_scope *scope,
             return false;
         }
     }
+}
+
+/*------------------------------------------------------------------------------
+ * Recursive process name
+ */
+
+struct csp_find_recursive_processes {
+    struct csp_process_visitor visitor;
+    struct csp_process_set *set;
+};
+
+static void
+csp_find_recursive_processes_visit(struct csp *csp,
+                                   struct csp_process_visitor *visitor,
+                                   struct csp_process *process)
+{
+    struct csp_find_recursive_processes *self =
+            container_of(visitor, struct csp_find_recursive_processes, visitor);
+    if (process->iface == &csp_recursive_process_iface) {
+        csp_process_set_add(self->set, process);
+    }
+}
+
+static struct csp_find_recursive_processes
+csp_find_recursive_processes(struct csp_process_set *set)
+{
+    struct csp_find_recursive_processes self = {
+            {csp_find_recursive_processes_visit}, set};
+    return self;
+}
+
+struct csp_recursive_name {
+    struct csp_name_visitor visitor;
+    struct csp_name_visitor *wrapped;
+};
+
+static void
+csp_recursive_name_visit(struct csp *csp, struct csp_name_visitor *visitor,
+                         const char *str, size_t length)
+{
+    struct csp_recursive_name *self =
+            container_of(visitor, struct csp_recursive_name, visitor);
+    csp_name_visitor_call_sized(csp, self->wrapped, str, length);
+}
+
+static struct csp_recursive_name
+csp_recursive_name(struct csp_name_visitor *wrapped)
+{
+    struct csp_recursive_name self = {{csp_recursive_name_visit}, wrapped};
+    return self;
+}
+
+static void
+csp_recursive_process_name(struct csp *csp, struct csp_process *process,
+                           struct csp_name_visitor *visitor)
+{
+    struct csp_recursive_process *recursive_process =
+            container_of(process, struct csp_recursive_process, process);
+    struct csp_process_set recursive_processes;
+    struct csp_find_recursive_processes find;
+    struct csp_recursive_name recurse;
+    size_t count;
+    struct csp_process **sorted;
+    size_t i;
+
+    /* If we're in the middle of visiting using a `csp_recursive_name` helper,
+     * then we just need to output the name of the process.  (That's what the
+     * recursive reference will look like in the middle of the process's
+     * definition.) */
+    if (visitor->visit == csp_recursive_name_visit) {
+        csp_name_visitor_call(csp, visitor, recursive_process->name);
+        return;
+    }
+
+    /* Otherwise we need to output the `let` statement that contains all of the
+     * definitions that are mutually recursive with the current one.  We'll
+     * first do a quick BFS to find them all. */
+    csp_process_set_init(&recursive_processes);
+    find = csp_find_recursive_processes(&recursive_processes);
+    csp_process_bfs(csp, process, &find.visitor);
+    csp_process_set_sort_by_index(&recursive_processes, &count, &sorted);
+    csp_process_set_done(&recursive_processes);
+
+    recurse = csp_recursive_name(visitor);
+    csp_name_visitor_call(csp, &recurse.visitor, "let");
+    for (i = 0; i < count; i++) {
+        struct csp_recursive_process *current_process =
+                container_of(sorted[i], struct csp_recursive_process, process);
+        csp_name_visitor_call(csp, &recurse.visitor, " ");
+        csp_name_visitor_call(csp, &recurse.visitor, current_process->name);
+        csp_name_visitor_call(csp, &recurse.visitor, "=");
+        csp_process_name(csp, current_process->definition, &recurse.visitor);
+    }
+    csp_name_visitor_call(csp, &recurse.visitor, " within ");
+    csp_name_visitor_call(csp, &recurse.visitor, recursive_process->name);
+    free(sorted);
 }

--- a/src/operators/sequential-composition.c
+++ b/src/operators/sequential-composition.c
@@ -67,6 +67,17 @@ struct csp_sequential_composition {
  */
 
 static void
+csp_sequential_composition_name(struct csp *csp, struct csp_process *process,
+                                struct csp_name_visitor *visitor)
+{
+    struct csp_sequential_composition *seq =
+            container_of(process, struct csp_sequential_composition, process);
+    csp_process_nested_name(csp, process, seq->p, visitor);
+    csp_name_visitor_call(csp, visitor, " ; ");
+    csp_process_nested_name(csp, process, seq->q, visitor);
+}
+
+static void
 csp_sequential_composition_initials(struct csp *csp,
                                     struct csp_process *process,
                                     struct csp_event_visitor *visitor)
@@ -143,8 +154,8 @@ csp_sequential_composition_free(struct csp *csp, struct csp_process *process)
 }
 
 static const struct csp_process_iface csp_sequential_composition_iface = {
-        csp_sequential_composition_initials, csp_sequential_composition_afters,
-        csp_sequential_composition_free};
+        3, csp_sequential_composition_name, csp_sequential_composition_initials,
+        csp_sequential_composition_afters, csp_sequential_composition_free};
 
 static csp_id
 csp_sequential_composition_get_id(struct csp_process *p, struct csp_process *q)

--- a/src/process.c
+++ b/src/process.c
@@ -7,6 +7,10 @@
 
 #include "process.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "ccan/container_of/container_of.h"
 #include "basics.h"
 #include "environment.h"
@@ -116,6 +120,40 @@ csp_collect_processes(struct csp_process_set *set)
 }
 
 /*------------------------------------------------------------------------------
+ * Name visitor
+ */
+
+void
+csp_name_visitor_call(struct csp *csp, struct csp_name_visitor *visitor,
+                      const char *str)
+{
+    visitor->visit(csp, visitor, str, strlen(str));
+}
+
+void
+csp_name_visitor_call_sized(struct csp *csp, struct csp_name_visitor *visitor,
+                            const char *str, size_t length)
+{
+    visitor->visit(csp, visitor, str, length);
+}
+
+static void
+csp_print_name_visit(struct csp *csp, struct csp_name_visitor *visitor,
+                     const char *str, size_t length)
+{
+    struct csp_print_name *self =
+            container_of(visitor, struct csp_print_name, visitor);
+    fwrite(str, length, 1, self->out);
+}
+
+struct csp_print_name
+csp_print_name(FILE *out)
+{
+    struct csp_print_name self = {{csp_print_name_visit}, out};
+    return self;
+}
+
+/*------------------------------------------------------------------------------
  * Processes
  */
 
@@ -123,6 +161,27 @@ void
 csp_process_free(struct csp *csp, struct csp_process *process)
 {
     process->iface->free(csp, process);
+}
+
+void
+csp_process_name(struct csp *csp, struct csp_process *process,
+                 struct csp_name_visitor *visitor)
+{
+    process->iface->name(csp, process, visitor);
+}
+
+void
+csp_process_nested_name(struct csp *csp, struct csp_process *process,
+                        struct csp_process *subprocess,
+                        struct csp_name_visitor *visitor)
+{
+    if (process->iface->precedence < subprocess->iface->precedence) {
+        csp_name_visitor_call(csp, visitor, "(");
+        subprocess->iface->name(csp, subprocess, visitor);
+        csp_name_visitor_call(csp, visitor, ")");
+    } else {
+        subprocess->iface->name(csp, subprocess, visitor);
+    }
 }
 
 void
@@ -282,6 +341,90 @@ void
 csp_process_set_clear(struct csp_process_set *set)
 {
     csp_set_clear(&set->set, NULL, NULL);
+}
+
+static int
+compare_process_index(const void *p1, const void *p2)
+{
+    struct csp_process *process1 = *((struct csp_process * const *) p1);
+    struct csp_process *process2 = *((struct csp_process * const *) p2);
+    if (process1->index < process2->index) {
+        return -1;
+    } else if (process1->index > process2->index) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+void
+csp_process_set_name(struct csp *csp, const struct csp_process_set *set,
+                     struct csp_name_visitor *visitor)
+{
+    struct csp_process_set_iterator iter;
+    size_t count;
+    struct csp_process **sorted;
+    size_t i;
+
+    /* Sort the set of processes in a stable way (i.e., that doesn't depend on
+     * the hash values, which can change from run to run).  Instead, use each
+     * process's index as its sort key. */
+    count = csp_process_set_size(set);
+    sorted = calloc(count, sizeof(struct csp_process *));
+    i = 0;
+    csp_process_set_foreach (set, &iter) {
+        struct csp_process *process = csp_process_set_iterator_get(&iter);
+        sorted[i++] = process;
+    }
+    qsort(sorted, count, sizeof(struct csp_process *), compare_process_index);
+
+    /* Then render the name of each process in the set. */
+    csp_name_visitor_call(csp, visitor, "{");
+    for (i = 0; i < count; i++) {
+        if (i > 0) {
+            csp_name_visitor_call(csp, visitor, ", ");
+        }
+        csp_process_name(csp, sorted[i], visitor);
+    }
+    csp_name_visitor_call(csp, visitor, "}");
+    free(sorted);
+}
+
+void
+csp_process_set_nested_name(struct csp *csp, struct csp_process *process,
+                            struct csp_process_set *subprocesses,
+                            const char *op, struct csp_name_visitor *visitor)
+{
+    struct csp_process_set_iterator iter;
+    size_t i;
+    struct csp_process *lhs = NULL;
+    struct csp_process *rhs = NULL;
+
+    /* If there aren't exactly two operands, use the replicated syntax. */
+    if (csp_process_set_size(subprocesses) != 2) {
+        csp_name_visitor_call(csp, visitor, op);
+        csp_name_visitor_call(csp, visitor, " ");
+        csp_process_set_name(csp, subprocesses, visitor);
+        return;
+    }
+
+    i = 0;
+    csp_process_set_foreach (subprocesses, &iter) {
+        if (i++ == 0) {
+            lhs = csp_process_set_iterator_get(&iter);
+        } else {
+            rhs = csp_process_set_iterator_get(&iter);
+        }
+    }
+    if (lhs->index > rhs->index) {
+        swap(lhs, rhs);
+    }
+
+    csp_process_nested_name(csp, process, lhs, visitor);
+    csp_name_visitor_call(csp, visitor, " ");
+    csp_name_visitor_call(csp, visitor, op);
+    csp_name_visitor_call(csp, visitor, " ");
+    csp_process_nested_name(csp, process, rhs, visitor);
 }
 
 bool

--- a/src/process.h
+++ b/src/process.h
@@ -200,6 +200,13 @@ csp_process_set_eq(const struct csp_process_set *set1,
 void
 csp_process_set_clear(struct csp_process_set *set);
 
+/* Fills in `count` with the number of processes in `set`, and `processes` with
+ * an array of those processes, sorted by their `index` values.  You must free
+ * `processes` when you're done with it (using `free(3)`). */
+void
+csp_process_set_sort_by_index(const struct csp_process_set *set, size_t *count,
+                              struct csp_process ***processes);
+
 /* Renders the name of each process in a set, in some braces to show that it's a
  * set. */
 void

--- a/src/process.h
+++ b/src/process.h
@@ -8,6 +8,9 @@
 #ifndef HST_PROCESS_H
 #define HST_PROCESS_H
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "basics.h"
 #include "event.h"
 
@@ -88,10 +91,40 @@ struct csp_collect_processes
 csp_collect_processes(struct csp_process_set *set);
 
 /*------------------------------------------------------------------------------
+ * Name visitor
+ */
+
+struct csp_name_visitor {
+    void (*visit)(struct csp *csp, struct csp_name_visitor *visitor,
+                  const char *str, size_t length);
+};
+
+void
+csp_name_visitor_call(struct csp *csp, struct csp_name_visitor *visitor,
+                      const char *str);
+
+void
+csp_name_visitor_call_sized(struct csp *csp, struct csp_name_visitor *visitor,
+                            const char *str, size_t length);
+
+struct csp_print_name {
+    struct csp_name_visitor visitor;
+    FILE *out;
+};
+
+struct csp_print_name
+csp_print_name(FILE *out);
+
+/*------------------------------------------------------------------------------
  * Processes
  */
 
 struct csp_process_iface {
+    unsigned int precedence;
+
+    void (*name)(struct csp *csp, struct csp_process *process,
+                 struct csp_name_visitor *visitor);
+
     void (*initials)(struct csp *csp, struct csp_process *process,
                      struct csp_event_visitor *visitor);
 
@@ -105,10 +138,23 @@ struct csp_process_iface {
 struct csp_process {
     csp_id id;
     const struct csp_process_iface *iface;
+    size_t index;
 };
 
 void
 csp_process_free(struct csp *csp, struct csp_process *process);
+
+void
+csp_process_name(struct csp *csp, struct csp_process *process,
+                 struct csp_name_visitor *visitor);
+
+/* Renders the name of `subprocess` as part of the name of `process`.  The
+ * precedence values of the two processes will determine whether we need to wrap
+ * `subprocess` in parentheses or not. */
+void
+csp_process_nested_name(struct csp *csp, struct csp_process *process,
+                        struct csp_process *subprocess,
+                        struct csp_name_visitor *visitor);
 
 void
 csp_process_visit_initials(struct csp *csp, struct csp_process *process,
@@ -153,6 +199,20 @@ csp_process_set_eq(const struct csp_process_set *set1,
 
 void
 csp_process_set_clear(struct csp_process_set *set);
+
+/* Renders the name of each process in a set, in some braces to show that it's a
+ * set. */
+void
+csp_process_set_name(struct csp *csp, const struct csp_process_set *set,
+                     struct csp_name_visitor *visitor);
+
+/* Renders a process whose operator can appear infix between two subprocesses,
+ * or prefix before a set of subprocesses.  Chooses which version to render
+ * based on the size of `subprocesses`. */
+void
+csp_process_set_nested_name(struct csp *csp, struct csp_process *process,
+                            struct csp_process_set *subprocesses,
+                            const char *op, struct csp_name_visitor *visitor);
 
 /* Add a single process to a set.  Return whether the process is new (i.e., it
  * wasn't already in `set`.) */

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -360,6 +360,8 @@ TEST_CASE_GROUP("recursion");
 
 TEST_CASE("let X=a → STOP within X")
 {
+    check_process_name(csp0("let X=a → STOP within X"),
+                       "let X=a → STOP within X");
     check_process_initials(csp0("let X=a → STOP within X"), events("a"));
     check_process_afters(csp0("let X=a → STOP within X"), event("a"),
                          csp0s("STOP"));
@@ -370,6 +372,8 @@ TEST_CASE("let X=a → STOP within X")
 
 TEST_CASE("let X=a → Y Y=b → X within X")
 {
+    check_process_name(csp0("let X=a → Y Y=b → X within X"),
+                       "let X=a → Y Y=b → X within X");
     check_process_initials(csp0("let X=a → Y Y=b → X within X"), events("a"));
     check_process_afters(csp0("let X=a → Y Y=b → X within X"), event("a"),
                          csp0s("Y@0"));

--- a/tests/test-refinement.c
+++ b/tests/test-refinement.c
@@ -406,12 +406,9 @@ TEST_CASE("a→a→STOP ~ a→a→STOP (separate branches)") {
             "within root";
     /* Normalize the process and verify we get all of the nodes and edges we
      * expect. */
-    printf("# === a\n");
     check_normalize(csp0(process), csp0s("root@0"));
-    printf("# === b\n");
     check_normalized_edge(csp0(process), csp0s("A@0", "D@0"), event("a"),
                           csp0s("B@0", "E@0"));
-    printf("# === c\n");
     check_normalized_edge(csp0(process), csp0s("B@0", "E@0"), event("a"),
                           csp0s("C@0", "F@0"));
 }


### PR DESCRIPTION
The process interface now includes a method for rendering the name of a process.  Or maybe their definitions?  We compute the names on the fly instead of storing them, which should help with memory consumption on especially large processes.  The process interface also includes the precedence level of the operator in question, which lets us decide whether we need to include parentheses when rendering the name of a bunch of nested subprocesses.