### PR TITLE
Fix interleave's handling of duplicate processes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,6 +32,7 @@ ForEachMacros:
   - csp_id_set_map_foreach
   - csp_map_foreach
   - csp_normalized_lts_nodes_foreach
+  - csp_process_bag_foreach
   - csp_process_set_foreach
   - csp_set_foreach
 IncludeCategories:

--- a/src/environment.c
+++ b/src/environment.c
@@ -271,6 +271,21 @@ csp_id_add_process(csp_id id, struct csp_process *process)
 }
 
 csp_id
+csp_id_add_process_bag(csp_id id, const struct csp_process_bag *bag)
+{
+    struct csp_process_bag_iterator iter;
+    csp_process_bag_foreach(bag, &iter) {
+        struct csp_process *process = csp_process_bag_iterator_get(&iter);
+        size_t count = csp_process_bag_iterator_get_count(&iter);
+        size_t j;
+        for (j = 0; j < count; j++) {
+            id = csp_id_add_process(id, process);
+        }
+    }
+    return id;
+}
+
+csp_id
 csp_id_add_process_set(csp_id id, const struct csp_process_set *set)
 {
     struct csp_process_set_iterator iter;

--- a/src/environment.h
+++ b/src/environment.h
@@ -121,6 +121,9 @@ csp_id
 csp_id_add_process(csp_id id, struct csp_process *process);
 
 csp_id
+csp_id_add_process_bag(csp_id id, const struct csp_process_bag *bag);
+
+csp_id
 csp_id_add_process_set(csp_id id, const struct csp_process_set *set);
 
 #endif /* HST_ENVIRONMENT_H */

--- a/src/map.c
+++ b/src/map.c
@@ -123,3 +123,17 @@ csp_map_insert(struct csp_map *map, csp_id id, csp_map_init_entry_f *init_entry,
     }
     return *entry;
 }
+
+void
+csp_map_remove(struct csp_map *map, csp_id id, csp_map_free_entry_f *free_entry,
+               void *ud)
+{
+    UNNEEDED int rc;
+    if (free_entry != NULL) {
+        void *entry = csp_map_get(map, id);
+        if (entry != NULL) {
+            free_entry(ud, entry);
+        }
+    }
+    JLD(rc, map->entries, id);
+}

--- a/src/map.h
+++ b/src/map.h
@@ -62,6 +62,10 @@ void *
 csp_map_insert(struct csp_map *map, csp_id id, csp_map_init_entry_f *init_entry,
                void *ud);
 
+void
+csp_map_remove(struct csp_map *map, csp_id id, csp_map_free_entry_f *free_entry,
+               void *ud);
+
 struct csp_map_iterator {
     void *const *entries;
     csp_id key;

--- a/src/operators.h
+++ b/src/operators.h
@@ -27,7 +27,7 @@ csp_external_choice(struct csp *csp, struct csp_process *p,
                     struct csp_process *q);
 
 struct csp_process *
-csp_interleave(struct csp *csp, const struct csp_process_set *ps);
+csp_interleave(struct csp *csp, const struct csp_process_bag *ps);
 
 struct csp_process *
 csp_internal_choice(struct csp *csp, struct csp_process *p,

--- a/src/process.h
+++ b/src/process.h
@@ -13,6 +13,8 @@
 
 #include "basics.h"
 #include "event.h"
+#include "map.h"
+#include "set.h"
 
 struct csp;
 struct csp_process;
@@ -228,5 +230,93 @@ csp_process_set_iterator_advance(struct csp_process_set_iterator *iter);
     for (csp_process_set_get_iterator((set), (iter)); \
          !csp_process_set_iterator_done((iter));      \
          csp_process_set_iterator_advance((iter)))
+
+/*------------------------------------------------------------------------------
+ * Process bags
+ */
+
+struct csp_process_bag {
+    struct csp_map map;
+    size_t count;
+};
+
+void
+csp_process_bag_init(struct csp_process_bag *bag);
+
+void
+csp_process_bag_done(struct csp_process_bag *bag);
+
+bool
+csp_process_bag_empty(const struct csp_process_bag *bag);
+
+size_t
+csp_process_bag_size(const struct csp_process_bag *bag);
+
+bool
+csp_process_bag_eq(const struct csp_process_bag *bag1,
+                   const struct csp_process_bag *bag2);
+
+void
+csp_process_bag_clear(struct csp_process_bag *bag);
+
+/* Fills in `count` with the number of processes in `bag`, and `processes` with
+ * an array of those processes, sorted by their `index` values.  You must free
+ * `processes` when you're done with it (using `free(3)`). */
+void
+csp_process_bag_sort_by_index(const struct csp_process_bag *bag, size_t *count,
+                              struct csp_process ***processes);
+
+/* Renders the name of each process in a bag, in some braces to show that it's a
+ * bag. */
+void
+csp_process_bag_name(struct csp *csp, const struct csp_process_bag *bag,
+                     struct csp_name_visitor *visitor);
+
+/* Renders a process whose operator can appear infix between two subprocesses,
+ * or prefix before a bag of subprocesses.  Chooses which version to render
+ * based on the size of `subprocesses`. */
+void
+csp_process_bag_nested_name(struct csp *csp, struct csp_process *process,
+                            struct csp_process_bag *subprocesses,
+                            const char *op, struct csp_name_visitor *visitor);
+
+/* Add a single process to a bag. */
+void
+csp_process_bag_add(struct csp_process_bag *bag, struct csp_process *process);
+
+/* Remove a single process from a bag.  `process` must be in the bag. */
+void
+csp_process_bag_remove(struct csp_process_bag *bag,
+                       struct csp_process *process);
+
+/* Add the contents of an existing bag to a bag. */
+void
+csp_process_bag_union(struct csp_process_bag *bag,
+                      const struct csp_process_bag *other);
+
+struct csp_process_bag_iterator {
+    struct csp_map_iterator iter;
+};
+
+void
+csp_process_bag_get_iterator(const struct csp_process_bag *bag,
+                             struct csp_process_bag_iterator *iter);
+
+struct csp_process *
+csp_process_bag_iterator_get(const struct csp_process_bag_iterator *iter);
+
+size_t
+csp_process_bag_iterator_get_count(const struct csp_process_bag_iterator *iter);
+
+bool
+csp_process_bag_iterator_done(struct csp_process_bag_iterator *iter);
+
+void
+csp_process_bag_iterator_advance(struct csp_process_bag_iterator *iter);
+
+#define csp_process_bag_foreach(bag, iter)            \
+    for (csp_process_bag_get_iterator((bag), (iter)); \
+         !csp_process_bag_iterator_done((iter));      \
+         csp_process_bag_iterator_advance((iter)))
 
 #endif /* HST_PROCESS_H */

--- a/tests/test-csp0.c
+++ b/tests/test-csp0.c
@@ -335,17 +335,17 @@ TEST_CASE("parse: let X = a → Y Y = b → X within X")
 TEST_CASE("parse: ⫴ {a → STOP, SKIP}")
 {
     struct csp *csp;
-    struct csp_process_set ps;
+    struct csp_process_bag ps;
     struct csp_process *p1;
     struct csp_process *root;
     /* Create the CSP environment. */
     check_alloc(csp, csp_new());
     p1 = csp_prefix(csp, csp_event_get("a"), csp->stop);
-    csp_process_set_init(&ps);
-    csp_process_set_add(&ps, p1);
-    csp_process_set_add(&ps, csp->skip);
+    csp_process_bag_init(&ps);
+    csp_process_bag_add(&ps, p1);
+    csp_process_bag_add(&ps, csp->skip);
     root = csp_interleave(csp, &ps);
-    csp_process_set_done(&ps);
+    csp_process_bag_done(&ps);
     /* Verify that we can parse the process, with and without whitespace. */
     check_csp0_eq("|||{a->STOP,SKIP}", root);
     check_csp0_eq(" |||{a->STOP,SKIP}", root);

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -317,7 +317,7 @@ TEST_CASE_GROUP("interleaving");
 
 TEST_CASE("STOP ⫴ STOP")
 {
-    check_process_name(csp0("STOP ⫴ STOP"), "⫴ {STOP}");
+    check_process_name(csp0("STOP ⫴ STOP"), "STOP ⫴ STOP");
     check_process_initials(csp0("STOP ⫴ STOP"), events("✔"));
     check_process_afters(csp0("STOP ⫴ STOP"), event("✔"), csp0s("STOP"));
     check_process_afters(csp0("STOP ⫴ STOP"), event("a"), csp0s());
@@ -346,6 +346,20 @@ TEST_CASE("(a → STOP) ⫴ (b → STOP ⊓ c → STOP)")
                                   "a → STOP ⫴ STOP", "STOP ⫴ STOP", "STOP"));
     check_process_traces_behavior(csp0("(a → STOP) ⫴ (b → STOP ⊓ c → STOP)"),
                                   events("a"));
+}
+
+TEST_CASE("a → STOP ⫴ a → STOP")
+{
+    check_process_name(csp0("a → STOP ⫴ a → STOP"), "a → STOP ⫴ a → STOP");
+    check_process_initials(csp0("a → STOP ⫴ a → STOP"), events("a"));
+    check_process_afters(csp0("a → STOP ⫴ a → STOP"), event("a"),
+                         csp0s("STOP ⫴ a → STOP"));
+    check_process_afters(csp0("a → STOP ⫴ a → STOP"), event("b"), csp0s());
+    check_process_afters(csp0("a → STOP ⫴ a → STOP"), event("τ"), csp0s());
+    check_process_reachable(csp0("a → STOP ⫴ a → STOP"),
+                            csp0s("a → STOP ⫴ a → STOP", "a → STOP ⫴ STOP",
+                                  "STOP ⫴ STOP", "STOP"));
+    check_process_traces_behavior(csp0("a → STOP ⫴ a → STOP"), events("a"));
 }
 
 TEST_CASE("a → STOP ⫴ b → STOP")
@@ -422,13 +436,14 @@ TEST_CASE("⫴ {a → STOP, b → STOP, c → STOP}")
                          csp0s("⫴ {a → STOP, b → STOP, STOP}"));
     check_process_afters(csp0("⫴ {a → STOP, b → STOP, c → STOP}"), event("τ"),
                          csp0s());
-    check_process_reachable(csp0("⫴ {a → STOP, b → STOP, c → STOP}"),
-                            csp0s("⫴ {a → STOP, b → STOP, c → STOP}",
-                                  "⫴ {STOP, b → STOP, c → STOP}",
-                                  "⫴ {a → STOP, STOP, c → STOP}",
-                                  "⫴ {a → STOP, b → STOP, STOP}",
-                                  "⫴ {a → STOP, STOP}", "⫴ {b → STOP, STOP}",
-                                  "⫴ {c → STOP, STOP}", "⫴ {STOP}", "STOP"));
+    check_process_reachable(
+            csp0("⫴ {a → STOP, b → STOP, c → STOP}"),
+            csp0s("⫴ {a → STOP, b → STOP, c → STOP}",
+                  "⫴ {STOP, a → STOP, b → STOP}",
+                  "⫴ {STOP, a → STOP, c → STOP}",
+                  "⫴ {STOP, b → STOP, c → STOP}", "⫴ {STOP, STOP, a → STOP}",
+                  "⫴ {STOP, STOP, b → STOP}", "⫴ {STOP, STOP, c → STOP}",
+                  "⫴ {STOP, STOP, STOP}", "STOP"));
     check_process_traces_behavior(csp0("⫴ {a → STOP, b → STOP, c → STOP}"),
                                   events("a", "b", "c"));
 }


### PR DESCRIPTION
P ||| P is not the same thing as |||{P} or P!  There are two copies of P, both of which get to execute, and whose traces are interleaved together. That means we can't treat the operand as a set, since that throws away duplicates.  A bag gives us exactly what we want, though — it keeps track of cardinality but not order.  (That is, P ||| Q is the same process as Q ||| P.)

Note that this is different from the choice operators: P □ P is the same as □{P} is the same as P.