### PR TITLE
Use AVL tree from CCAN instead of libjudy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,6 +28,7 @@ ExperimentalAutoDetectBinPacking: false
 ForEachMacros:
   - csp_event_set_foreach
   - csp_id_map_foreach
+  - csp_id_pair_set_foreach
   - csp_id_set_foreach
   - csp_id_set_map_foreach
   - csp_map_foreach

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ script: .travis/test.sh
 addons:
   apt:
     packages:
-      - libjudy-dev
       - valgrind

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,12 +75,18 @@ libhst_la_SOURCES = \
 	src/operators/prefix.c \
 	src/operators/recursion.c \
 	src/operators/sequential-composition.c \
+	third_party/ccan/avl/avl.h \
+	third_party/ccan/avl/avl.c \
 	third_party/ccan/build_assert/build_assert.h \
 	third_party/ccan/compiler/compiler.h \
 	third_party/ccan/container_of/container_of.h \
 	third_party/ccan/hash/hash.h \
 	third_party/ccan/hash/hash.c \
-	third_party/ccan/likely/likely.h
+	third_party/ccan/likely/likely.h \
+	third_party/ccan/order/order.h \
+	third_party/ccan/order/order.c \
+	third_party/ccan/ptrint/ptrint.h \
+	third_party/ccan/typesafe_cb/typesafe_cb.h
 libhst_la_LDFLAGS = -export-symbols-regex '^csp_[^_]'
 
 libtests_la_SOURCES = \

--- a/README.md
+++ b/README.md
@@ -16,18 +16,12 @@ useful, that would be a pleasant side effect!
 ## Building
 
 HST is implemented in C, and uses the [autotools][] for its build environment.
-Its only dependency is on [Judy][], which provides some useful data structures.
-To install it, look for a package called `judy`, `libjudy` or `libjudy-dev` in
-your package manager.
+To install all of the build tools and dependencies on [Arch Linux][], you'd use:
 
-As an example, to install all of the build tools and dependencies on [Arch
-Linux][], you'd use something like:
-
-    $ sudo pacman -S base-devel judy
+    $ sudo pacman -S base-devel
 
 [Arch Linux]: https://www.archlinux.org/
 [autotools]: https://autotools.io/index.html
-[Judy]: http://judy.sourceforge.net/
 
 Once all of the dependencies are installed, build the code:
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
-# Copyright © 2016, HST Project.
+# Copyright © 2016-2017, HST Project.
 # Please see the COPYING file in this distribution for license details.
 # ------------------------------------------------------------------------------
 
@@ -23,7 +23,6 @@ AC_C_BIGENDIAN([AC_DEFINE([HAVE_BIG_ENDIAN], [1],
                [AC_DEFINE([HAVE_LITTLE_ENDIAN], [1],
                           [Whether this system is little-endian])])
 AC_C_TYPEOF
-AC_CHECK_LIB([Judy], [Judy1Set], [], [AC_MSG_ERROR([libjudy not found])])
 AX_GCC_BUILTIN([__builtin_expect])
 AX_GCC_FUNC_ATTRIBUTE([constructor])
 AX_GCC_FUNC_ATTRIBUTE([unused])

--- a/src/environment.c
+++ b/src/environment.c
@@ -142,22 +142,23 @@ csp_id_process_map_free_entry(void *ud, void *entry)
     csp_process_free(csp, process);
 }
 
-void
+static void
 csp_id_process_map_done(struct csp *csp, struct csp_id_process_map *map)
 {
     csp_map_done(&map->map, csp_id_process_map_free_entry, csp);
 }
 
-struct csp_process *
+static struct csp_process *
 csp_id_process_map_get(const struct csp_id_process_map *map, csp_id id)
 {
     return csp_map_get(&map->map, id);
 }
 
-struct csp_process **
-csp_id_process_map_at(struct csp_id_process_map *map, csp_id id)
+static void
+csp_id_process_map_insert(struct csp_id_process_map *map, csp_id id,
+                          struct csp_process *process)
 {
-    return (struct csp_process **) csp_map_at(&map->map, id);
+    csp_map_insert(&map->map, id, process);
 }
 
 /*------------------------------------------------------------------------------
@@ -202,10 +203,8 @@ void
 csp_register_process(struct csp *pcsp, struct csp_process *process)
 {
     struct csp_priv *csp = container_of(pcsp, struct csp_priv, public);
-    struct csp_process **entry =
-            csp_id_process_map_at(&csp->processes, process->id);
-    assert(*entry == NULL);
-    *entry = process;
+    assert(csp_id_process_map_get(&csp->processes, process->id) == NULL);
+    csp_id_process_map_insert(&csp->processes, process->id, process);
     process->index = csp->process_count++;
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -77,10 +77,17 @@ csp_event_map_done(struct csp_event_map *map)
     csp_map_done(&map->map, csp_event_map_free_entry, NULL);
 }
 
-static const struct csp_event **
-csp_event_map_at(struct csp_event_map *map, csp_id id)
+static const struct csp_event *
+csp_event_map_get(struct csp_event_map *map, csp_id id)
 {
-    return (const struct csp_event **) csp_map_at(&map->map, id);
+    return csp_map_get(&map->map, id);
+}
+
+static void
+csp_event_map_insert(struct csp_event_map *map, csp_id id,
+                     const struct csp_event *event)
+{
+    csp_map_insert(&map->map, id, (void *) event);
 }
 
 static struct csp_event_map events;
@@ -124,11 +131,12 @@ csp_event_get_sized(const char *name, size_t name_length)
 {
     struct csp_event_map *map = get_event_map();
     csp_id event_id = hash_sized_name(name, name_length);
-    const struct csp_event **event = csp_event_map_at(map, event_id);
-    if (unlikely(*event == NULL)) {
-        *event = csp_event_new(event_id, name, name_length);
+    const struct csp_event *event = csp_event_map_get(map, event_id);
+    if (unlikely(event == NULL)) {
+        event = csp_event_new(event_id, name, name_length);
+        csp_event_map_insert(map, event_id, event);
     }
-    return *event;
+    return event;
 }
 
 csp_id

--- a/src/id-map.c
+++ b/src/id-map.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -56,10 +56,9 @@ csp_id_map_get(const struct csp_id_map *map, csp_id id)
 csp_id
 csp_id_map_insert(struct csp_id_map *map, csp_id from, csp_id to)
 {
-    void **entry = csp_map_at(&map->map, from);
-    csp_id result = (uintptr_t) *entry;
-    *entry = (void *) to;
-    return result;
+    csp_id old_entry = (uintptr_t) csp_map_get(&map->map, from);
+    csp_map_insert(&map->map, from, (void *) to);
+    return old_entry;
 }
 
 void
@@ -84,11 +83,11 @@ csp_id_map_iterator_advance(struct csp_id_map_iterator *iter)
 csp_id
 csp_id_map_iterator_get_from(const struct csp_id_map_iterator *iter)
 {
-    return iter->iter.key;
+    return csp_map_iterator_get_key(&iter->iter);
 }
 
 csp_id
 csp_id_map_iterator_get_to(const struct csp_id_map_iterator *iter)
 {
-    return (uintptr_t) *iter->iter.value;
+    return (uintptr_t) csp_map_iterator_get_value(&iter->iter);
 }

--- a/src/id-pair.c
+++ b/src/id-pair.c
@@ -9,9 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define JUDYERROR_NOTEST 1
-#include <Judy.h>
-
 #include "ccan/compiler/compiler.h"
 #include "ccan/likely/likely.h"
 #include "id-pair.h"
@@ -20,30 +17,11 @@
  * Sets
  */
 
-void
-csp_id_pair_set_init(struct csp_id_pair_set *set)
-{
-    set->pairs = set->internal;
-    set->allocated_count = CSP_ID_PAIR_SET_INTERNAL_SIZE;
-    set->count = 0;
-}
-
-void
-csp_id_pair_set_done(struct csp_id_pair_set *set)
-{
-    if (set->pairs != set->internal) {
-        free(set->pairs);
-    }
-}
-
 static int
 csp_id_pair_cmp(const void *vp1, const void *vp2)
 {
     const struct csp_id_pair *p1 = vp1;
     const struct csp_id_pair *p2 = vp2;
-    /* This comparison ordering happens to line up with how we're storing pairs
-     * in the set builder, which defines in which order the pairs are added to
-     * the array when building the set. */
 
     if (p1->from < p2->from) {
         return -1;
@@ -60,185 +38,92 @@ csp_id_pair_cmp(const void *vp1, const void *vp2)
     return 0;
 }
 
+void
+csp_id_pair_set_init(struct csp_id_pair_set *set)
+{
+    set->avl = avl_new(csp_id_pair_cmp);
+    assert(set->avl != NULL);
+}
+
+void
+csp_id_pair_set_done(struct csp_id_pair_set *set)
+{
+    struct csp_id_pair_set_iterator iter;
+    csp_id_pair_set_foreach (set, &iter) {
+        const struct csp_id_pair *pair = csp_id_pair_set_iterator_get(&iter);
+        free((void *) pair);
+    }
+    avl_free(set->avl);
+}
+
+void
+csp_id_pair_set_clear(struct csp_id_pair_set *set)
+{
+    csp_id_pair_set_done(set);
+    csp_id_pair_set_init(set);
+}
+
+bool
+csp_id_pair_set_empty(const struct csp_id_pair_set *set)
+{
+    return avl_count(set->avl) == 0;
+}
+
+size_t
+csp_id_pair_set_size(const struct csp_id_pair_set *set)
+{
+    return avl_count(set->avl);
+}
+
+void
+csp_id_pair_set_add(struct csp_id_pair_set *set, struct csp_id_pair pair)
+{
+    if (avl_lookup(set->avl, &pair) == NULL) {
+        struct csp_id_pair *pair_copy = malloc(sizeof(struct csp_id_pair));
+        *pair_copy = pair;
+        avl_insert(set->avl, pair_copy, pair_copy);
+    }
+}
+
 bool
 csp_id_pair_set_contains(const struct csp_id_pair_set *set,
                          struct csp_id_pair pair)
 {
-    /* The pairs list is sorted, so we can do a binary search to determine if an
-     * element is in the set. */
-    void *vpair = bsearch(&pair, set->pairs, set->count,
-                          sizeof(struct csp_id_pair), csp_id_pair_cmp);
-    return vpair != NULL;
+    return avl_lookup(set->avl, &pair) != NULL;
 }
-
-bool
-csp_id_pair_set_eq(const struct csp_id_pair_set *set1,
-                   const struct csp_id_pair_set *set2)
-{
-    if (set1->count != set2->count) {
-        return false;
-    }
-    return memcmp(set1->pairs, set2->pairs,
-                  set1->count * sizeof(struct csp_id_pair)) == 0;
-}
-
-void
-csp_id_pair_set_builder_init(struct csp_id_pair_set_builder *builder)
-{
-    builder->count = 0;
-    builder->working_set = NULL;
-}
-
-void
-csp_id_pair_set_builder_done(struct csp_id_pair_set_builder *builder)
-{
-    {
-        UNNEEDED Word_t dummy;
-        Word_t *vtos;
-        csp_id from = 0;
-        JLF(vtos, builder->working_set, from);
-        while (vtos != NULL) {
-            void *tos = (void *) *vtos;
-            J1FA(dummy, tos);
-            JLN(vtos, builder->working_set, from);
-        }
-        JLFA(dummy, builder->working_set);
-    }
-}
-
-void
-csp_id_pair_set_builder_add(struct csp_id_pair_set_builder *builder,
-                            struct csp_id_pair pair)
-{
-    int rc;
-    Word_t *vtos;
-    void **tos;
-    JLI(vtos, builder->working_set, pair.from);
-    tos = (void **) vtos;
-    J1S(rc, *tos, pair.to);
-    builder->count += rc;
-}
-
-#define CSP_ID_PAIR_SET_FIRST_ALLOCATION_COUNT 32
-
-static void
-csp_id_pair_set_ensure_size(struct csp_id_pair_set *set, size_t count)
-{
-    set->count = count;
-    if (unlikely(count > set->allocated_count)) {
-        if (set->pairs == set->internal) {
-            size_t new_count = CSP_ID_PAIR_SET_FIRST_ALLOCATION_COUNT;
-            while (count > new_count) {
-                new_count *= 2;
-            }
-            set->pairs = malloc(new_count * sizeof(struct csp_id_pair));
-            assert(set->pairs != NULL);
-            set->allocated_count = new_count;
-        } else {
-            /* Whenever we reallocate, at least double the size of the existing
-             * set. */
-            struct csp_id_pair *new_pairs;
-            size_t new_count = set->allocated_count;
-            do {
-                new_count *= 2;
-            } while (count > new_count);
-            new_pairs =
-                    realloc(set->pairs, new_count * sizeof(struct csp_id_pair));
-            assert(new_pairs != NULL);
-            set->pairs = new_pairs;
-            set->allocated_count = new_count;
-        }
-    }
-}
-
-void
-csp_id_pair_set_build(struct csp_id_pair_set *set,
-                      struct csp_id_pair_set_builder *builder)
-{
-    UNNEEDED Word_t dummy;
-    size_t i = 0;
-    Word_t *vtos;
-    csp_id from = 0;
-
-    csp_id_pair_set_ensure_size(set, builder->count);
-    JLF(vtos, builder->working_set, from);
-    while (vtos != NULL) {
-        void **tos = (void **) vtos;
-        int found;
-        csp_id to = 0;
-        J1F(found, *tos, to);
-        while (found) {
-            set->pairs[i].from = from;
-            set->pairs[i].to = to;
-            i++;
-            J1N(found, *tos, to);
-        }
-
-        tos = (void **) vtos;
-        J1FA(dummy, *tos);
-        JLN(vtos, builder->working_set, from);
-    }
-
-    JLFA(dummy, builder->working_set);
-    builder->count = 0;
-}
-
-#define swap_id_pair_set(a, b)         \
-    do {                               \
-        struct csp_id_pair_set __swap; \
-        __swap = (a);                  \
-        (a) = (b);                     \
-        (b) = __swap;                  \
-    } while (0)
 
 void
 csp_id_pair_set_union(struct csp_id_pair_set *set1,
                       const struct csp_id_pair_set *set2)
 {
-    size_t i1;
-    size_t i2;
-    size_t d;
-    size_t duplicates = 0;
-    struct csp_id_pair_set dest;
-
-    /* Merge the two sorted list of pairs together, stopping when we run out of
-     * pairs in one or both of the sources. */
-    csp_id_pair_set_init(&dest);
-    csp_id_pair_set_ensure_size(&dest, set1->count + set2->count);
-    for (d = 0, i1 = 0, i2 = 0; i1 < set1->count && i2 < set2->count;) {
-        const struct csp_id_pair *p1 = &set1->pairs[i1];
-        const struct csp_id_pair *p2 = &set2->pairs[i2];
-        int cmp = csp_id_pair_cmp(p1, p2);
-        if (cmp < 0) {
-            dest.pairs[d++] = *p1;
-            i1++;
-        } else {
-            dest.pairs[d++] = *p2;
-            i2++;
-            if (cmp == 0) {
-                i1++;
-                duplicates++;
-            }
-        }
+    struct csp_id_pair_set_iterator iter;
+    csp_id_pair_set_foreach (set2, &iter) {
+        const struct csp_id_pair *pair = csp_id_pair_set_iterator_get(&iter);
+        csp_id_pair_set_add(set1, *pair);
     }
+}
 
-    /* Copy the remainder of set1 or set2, if any, to the result. */
-    for (; i1 < set1->count; i1++) {
-        dest.pairs[d++] = set1->pairs[i1];
-    }
-    for (; i2 < set2->count; i2++) {
-        dest.pairs[d++] = set2->pairs[i2];
-    }
+void
+csp_id_pair_set_get_iterator(const struct csp_id_pair_set *set,
+                             struct csp_id_pair_set_iterator *iter)
+{
+    avl_iter_begin(&iter->iter, set->avl, FORWARD);
+}
 
-    /* If there were any pairs that were in both set1 and set2, then we
-     * overestimated the size of dest when we first allocated space for its
-     * pairs array. */
-    dest.count = d;
+const struct csp_id_pair *
+csp_id_pair_set_iterator_get(const struct csp_id_pair_set_iterator *iter)
+{
+    return iter->iter.key;
+}
 
-    /* Swap the dest into the output parameter and free the old copy. */
-    csp_id_pair_set_done(set1);
-    swap_id_pair_set(dest, *set1);
-    if (set1->pairs == dest.internal) {
-        set1->pairs = set1->internal;
-    }
+bool
+csp_id_pair_set_iterator_done(struct csp_id_pair_set_iterator *iter)
+{
+    return iter->iter.node == NULL;
+}
+
+void
+csp_id_pair_set_iterator_advance(struct csp_id_pair_set_iterator *iter)
+{
+    avl_iter_next(&iter->iter);
 }

--- a/src/id-set-map.c
+++ b/src/id-set-map.c
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -55,20 +55,16 @@ csp_id_set_map_get(const struct csp_id_set_map *map, csp_id id)
     return csp_map_get(&map->map, id);
 }
 
-static void
-csp_id_set_map_init_entry(void *ud, void **ventry)
-{
-    struct csp_id_set *set = malloc(sizeof(struct csp_id_set));
-    assert(set != NULL);
-    csp_id_set_init(set);
-    *ventry = set;
-}
-
 bool
 csp_id_set_map_insert(struct csp_id_set_map *map, csp_id from, csp_id to)
 {
-    struct csp_id_set *set =
-            csp_map_insert(&map->map, from, csp_id_set_map_init_entry, NULL);
+    struct csp_id_set *set = csp_map_get(&map->map, from);
+    if (unlikely(set == NULL)) {
+        set = malloc(sizeof(struct csp_id_set));
+        assert(set != NULL);
+        csp_id_set_init(set);
+        csp_map_insert(&map->map, from, set);
+    }
     return csp_id_set_add(set, to);
 }
 
@@ -105,11 +101,11 @@ csp_id_set_map_iterator_advance(struct csp_id_set_map_iterator *iter)
 csp_id
 csp_id_set_map_iterator_get_from(const struct csp_id_set_map_iterator *iter)
 {
-    return iter->iter.key;
+    return csp_map_iterator_get_key(&iter->iter);
 }
 
 const struct csp_id_set *
 csp_id_set_map_iterator_get_tos(const struct csp_id_set_map_iterator *iter)
 {
-    return *iter->iter.value;
+    return csp_map_iterator_get_value(&iter->iter);
 }

--- a/src/map.c
+++ b/src/map.c
@@ -1,60 +1,48 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
 
 #include "map.h"
 
+#include <assert.h>
 #include <stdbool.h>
 
-#define JUDYERROR_NOTEST 1
-#include <Judy.h>
-
+#include "ccan/avl/avl.h"
 #include "ccan/compiler/compiler.h"
+
+static int
+csp_map_cmp(const void *key1, const void *key2)
+{
+    if (key1 < key2) {
+        return -1;
+    } else if (key1 > key2) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
 
 void
 csp_map_init(struct csp_map *map)
 {
-    map->entries = NULL;
+    map->avl = avl_new(csp_map_cmp);
+    assert(map->avl != NULL);
 }
 
 void
 csp_map_done(struct csp_map *map, csp_map_free_entry_f *free_entry, void *ud)
 {
-    UNNEEDED Word_t dummy;
     if (free_entry != NULL) {
-        Word_t *ventry;
-        csp_id id = 0;
-        JLF(ventry, map->entries, id);
-        while (ventry != NULL) {
-            void *entry = (void *) *ventry;
-            free_entry(ud, entry);
-            JLN(ventry, map->entries, id);
+        struct csp_map_iterator iter;
+        csp_map_foreach (map, &iter) {
+            void *value = csp_map_iterator_get_value(&iter);
+            free_entry(ud, value);
         }
     }
-    JLFA(dummy, map->entries);
-}
-
-void
-csp_map_get_iterator(const struct csp_map *map, struct csp_map_iterator *iter)
-{
-    iter->entries = &map->entries;
-    iter->key = 0;
-    JLF(iter->value, *iter->entries, iter->key);
-}
-
-bool
-csp_map_iterator_done(struct csp_map_iterator *iter)
-{
-    return iter->value == NULL;
-}
-
-void
-csp_map_iterator_advance(struct csp_map_iterator *iter)
-{
-    JLN(iter->value, *iter->entries, iter->key);
+    avl_free(map->avl);
 }
 
 bool
@@ -63,12 +51,12 @@ csp_map_eq(const struct csp_map *map1, const struct csp_map *map2,
 {
     struct csp_map_iterator iter;
     csp_map_foreach (map1, &iter) {
-        void *entry1 = *iter.value;
-        void *entry2 = csp_map_get(map2, iter.key);
-        if (entry2 == NULL) {
+        void *value1 = csp_map_iterator_get_value(&iter);
+        void *value2 = csp_map_get(map2, csp_map_iterator_get_key(&iter));
+        if (value2 == NULL) {
             return false;
         }
-        if (!entry_eq(ud, entry1, entry2)) {
+        if (!entry_eq(ud, value1, value2)) {
             return false;
         }
     }
@@ -78,62 +66,66 @@ csp_map_eq(const struct csp_map *map1, const struct csp_map *map2,
 bool
 csp_map_empty(const struct csp_map *map)
 {
-    return map->entries == NULL;
+    return avl_count(map->avl) == 0;
 }
 
 size_t
 csp_map_size(const struct csp_map *map)
 {
-    Word_t count;
-    JLC(count, map->entries, 0, -1);
-    return count;
+    return avl_count(map->avl);
 }
 
 void *
 csp_map_get(const struct csp_map *map, csp_id id)
 {
-    Word_t *ventry;
-    JLG(ventry, map->entries, id);
-    if (ventry == NULL) {
-        return NULL;
-    } else {
-        void **entry = (void **) ventry;
-        return *entry;
-    }
+    return avl_lookup(map->avl, (void *) id);
 }
 
-void **
-csp_map_at(struct csp_map *map, csp_id id)
+bool
+csp_map_insert(struct csp_map *map, csp_id id, void *value)
 {
-    Word_t *ventry;
-    JLI(ventry, map->entries, id);
-    return (void **) ventry;
-}
-
-void *
-csp_map_insert(struct csp_map *map, csp_id id, csp_map_init_entry_f *init_entry,
-               void *ud)
-{
-    Word_t *ventry;
-    void **entry;
-    JLI(ventry, map->entries, id);
-    entry = (void **) ventry;
-    if (*entry == NULL) {
-        init_entry(ud, entry);
-    }
-    return *entry;
+    return avl_insert(map->avl, (void *) id, value);
 }
 
 void
 csp_map_remove(struct csp_map *map, csp_id id, csp_map_free_entry_f *free_entry,
                void *ud)
 {
-    UNNEEDED int rc;
     if (free_entry != NULL) {
         void *entry = csp_map_get(map, id);
         if (entry != NULL) {
             free_entry(ud, entry);
         }
     }
-    JLD(rc, map->entries, id);
+    avl_remove(map->avl, (void *) id);
+}
+
+void
+csp_map_get_iterator(const struct csp_map *map, struct csp_map_iterator *iter)
+{
+    avl_iter_begin(&iter->iter, map->avl, FORWARD);
+}
+
+csp_id
+csp_map_iterator_get_key(const struct csp_map_iterator *iter)
+{
+    return (uintptr_t) iter->iter.key;
+}
+
+void *
+csp_map_iterator_get_value(const struct csp_map_iterator *iter)
+{
+    return (void *) iter->iter.value;
+}
+
+bool
+csp_map_iterator_done(struct csp_map_iterator *iter)
+{
+    return iter->iter.node == NULL;
+}
+
+void
+csp_map_iterator_advance(struct csp_map_iterator *iter)
+{
+    avl_iter_next(&iter->iter);
 }

--- a/src/map.h
+++ b/src/map.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * -----------------------------------------------------------------------------
- * Copyright © 2016, HST Project.
+ * Copyright © 2016-2017, HST Project.
  * Please see the COPYING file in this distribution for license details.
  * -----------------------------------------------------------------------------
  */
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "ccan/avl/avl.h"
 #include "basics.h"
 
 /* A map whose keys are IDs, and whose values are anything pointer-sized that
@@ -19,7 +20,7 @@
  * one of those directly.  (Take a look at csp_id_map to see an example of how
  * to implement one of those more specialized map types.) */
 struct csp_map {
-    void *entries;
+    AVL *avl;
 };
 
 void
@@ -44,36 +45,30 @@ csp_map_empty(const struct csp_map *map);
 size_t
 csp_map_size(const struct csp_map *map);
 
-/* Return NULL if the entry doesn't exist. */
+/* Returns NULL if the entry doesn't exist. */
 void *
 csp_map_get(const struct csp_map *map, csp_id id);
 
-/* Creates an entry if it doesn't exist, initialized to NULL. */
-void **
-csp_map_at(struct csp_map *map, csp_id id);
-
-typedef void
-csp_map_init_entry_f(void *ud, void **entry);
-
-/* Ensure that `map` contains an entry with the given `id`, creating it if
- * necessary.  If the entry is new, calls `init_entry` to initialize it.  Return
- * the entry. */
-void *
-csp_map_insert(struct csp_map *map, csp_id id, csp_map_init_entry_f *init_entry,
-               void *ud);
+/* Inserts a new entry into `map`.  Returns true if the entry is new. */
+bool
+csp_map_insert(struct csp_map *map, csp_id id, void *value);
 
 void
 csp_map_remove(struct csp_map *map, csp_id id, csp_map_free_entry_f *free_entry,
                void *ud);
 
 struct csp_map_iterator {
-    void *const *entries;
-    csp_id key;
-    void **value;
+    AvlIter iter;
 };
 
 void
 csp_map_get_iterator(const struct csp_map *map, struct csp_map_iterator *iter);
+
+csp_id
+csp_map_iterator_get_key(const struct csp_map_iterator *iter);
+
+void *
+csp_map_iterator_get_value(const struct csp_map_iterator *iter);
 
 bool
 csp_map_iterator_done(struct csp_map_iterator *iter);

--- a/src/set.h
+++ b/src/set.h
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "ccan/avl/avl.h"
+
 /* A set of any pointer that you want.  The pointers must be directly comparable
  * — i.e., a pointer is only equal to itself; there isn't any way to define a
  * deeper comparison operation for your elements.  (If you want to do that, use
@@ -19,7 +21,7 @@
  * instead, there are several helper types that store particular kinds of
  * elements, and you'll use one of those directly. */
 struct csp_set {
-    void *elements;
+    AVL *avl;
 };
 
 void
@@ -76,9 +78,7 @@ bool
 csp_set_union(struct csp_set *set, const struct csp_set *other);
 
 struct csp_set_iterator {
-    void *const *elements;
-    uintptr_t current;
-    int found;
+    AvlIter iter;
 };
 
 void

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -977,19 +977,15 @@ pair_set_factory(struct csp *csp, void *vids)
     size_t  i;
     struct csp_id_factory_array *ids = vids;
     struct csp_id_pair_set *set = malloc(sizeof(struct csp_id_pair_set));
-    struct csp_id_pair_set_builder builder;
     assert(set != NULL);
     csp_id_pair_set_init(set);
     test_case_cleanup_register(csp_id_pair_set_free_, set);
-    csp_id_pair_set_builder_init(&builder);
     for (i = 0; i < ids->count;) {
         csp_id from = csp_id_factory_create(csp, ids->factories[i++]);
         csp_id to = csp_id_factory_create(csp, ids->factories[i++]);
         struct csp_id_pair pair = {from, to};
-        csp_id_pair_set_builder_add(&builder, pair);
+        csp_id_pair_set_add(set, pair);
     }
-    csp_id_pair_set_build(set, &builder);
-    csp_id_pair_set_builder_done(&builder);
     return set;
 }
 

--- a/tests/test-id-pairs.c
+++ b/tests/test-id-pairs.c
@@ -17,13 +17,13 @@ TEST_CASE_GROUP("ID pair sets");
 TEST_CASE("can create empty sets via factory")
 {
     struct csp_id_pair_set *set = make_pair_set();
-    check(set->count == 0);
+    check(csp_id_pair_set_size(set) == 0);
 }
 
 TEST_CASE("can create 1-element set via factory")
 {
     struct csp_id_pair_set *set = make_pair_set(id(10), id(20));
-    check(set->count == 1);
+    check(csp_id_pair_set_size(set) == 1);
     check(csp_id_pair_set_contains(set, pair(10, 20)));
 }
 
@@ -32,7 +32,7 @@ TEST_CASE("can create 5-element set via factory")
     struct csp_id_pair_set *set =
             make_pair_set(id(10), id(15), id(10), id(25), id(30), id(35),
                           id(40), id(45), id(50), id(55));
-    check(set->count == 5);
+    check(csp_id_pair_set_size(set) == 5);
     check(csp_id_pair_set_contains(set, pair(10, 15)));
     check(csp_id_pair_set_contains(set, pair(10, 25)));
     check(csp_id_pair_set_contains(set, pair(30, 35)));
@@ -45,29 +45,11 @@ TEST_CASE("duplicates are ignored when creating set via factory")
     struct csp_id_pair_set *set =
             make_pair_set(id(10), id(15), id(10), id(15), id(30), id(35),
                           id(40), id(45), id(50), id(55));
-    check(set->count == 4);
+    check(csp_id_pair_set_size(set) == 4);
     check(csp_id_pair_set_contains(set, pair(10, 15)));
     check(csp_id_pair_set_contains(set, pair(30, 35)));
     check(csp_id_pair_set_contains(set, pair(40, 45)));
     check(csp_id_pair_set_contains(set, pair(50, 55)));
-}
-
-TEST_CASE("pairs in set are sorted")
-{
-    struct csp_id_pair_set *set =
-            make_pair_set(id(20), id(45), id(20), id(15), id(20), id(55),
-                          id(30), id(35), id(10), id(15));
-    check(set->count == 5);
-    check_id_eq(set->pairs[0].from, 10);
-    check_id_eq(set->pairs[0].to, 15);
-    check_id_eq(set->pairs[1].from, 20);
-    check_id_eq(set->pairs[1].to, 15);
-    check_id_eq(set->pairs[2].from, 20);
-    check_id_eq(set->pairs[2].to, 45);
-    check_id_eq(set->pairs[3].from, 20);
-    check_id_eq(set->pairs[3].to, 55);
-    check_id_eq(set->pairs[4].from, 30);
-    check_id_eq(set->pairs[4].to, 35);
 }
 
 static void
@@ -79,8 +61,13 @@ check_union(struct csp_id_pair_set_factory lhs,
     struct csp_id_pair_set *rhs_set = csp_id_pair_set_factory_create(NULL, rhs);
     struct csp_id_pair_set *expected_set =
             csp_id_pair_set_factory_create(NULL, expected);
+    struct csp_id_pair_set_iterator iter;
     csp_id_pair_set_union(lhs_set, rhs_set);
-    check(csp_id_pair_set_eq(lhs_set, expected_set));
+    check(csp_id_pair_set_size(lhs_set) == csp_id_pair_set_size(expected_set));
+    csp_id_pair_set_foreach (expected_set, &iter) {
+        const struct csp_id_pair *pair = csp_id_pair_set_iterator_get(&iter);
+        check(csp_id_pair_set_contains(lhs_set, *pair));
+    }
 }
 
 TEST_CASE("can union two sets")

--- a/third_party/ccan/avl/LICENSE
+++ b/third_party/ccan/avl/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/BSD-MIT

--- a/third_party/ccan/avl/_info
+++ b/third_party/ccan/avl/_info
@@ -1,0 +1,83 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * avl - Key-value dictionary based on AVL trees
+ *
+ * A simple, well-tested implementation of AVL trees for mapping
+ * unique keys to values.  This implementation supports insertion,
+ * removal, lookup, and traversal.
+ *
+ * An AVL tree is a self-balancing binary tree that performs
+ * insertion, removal, and lookup in O(log n) time per operation.
+ *
+ * Example:
+ * #include <ccan/avl/avl.h>
+ * 
+ * #include <stdio.h>
+ * #include <stdlib.h>
+ * #include <string.h>
+ * 
+ * struct tally {
+ * 	long count;
+ * };
+ * #define new_tally() calloc(1, sizeof(struct tally))
+ * 
+ * static void chomp(char *str)
+ * {
+ * 	char *end = strchr(str, 0);
+ * 	if (end > str && end[-1] == '\n')
+ * 		end[-1] = 0;
+ * }
+ * 
+ * int main(void)
+ * {
+ * 	AVL          *avl = avl_new((total_order_noctx_cb) strcmp);
+ * 	AvlIter       i;
+ * 	struct tally *tally;
+ * 	char          line[256];
+ * 	
+ * 	while (fgets(line, sizeof(line), stdin))
+ * 	{
+ * 		chomp(line);
+ * 		
+ * 		tally = avl_lookup(avl, line);
+ * 		if (tally == NULL)
+ * 			avl_insert(avl, strdup(line), tally = new_tally());
+ * 		
+ * 		tally->count++;
+ * 	}
+ * 	
+ * 	avl_foreach(i, avl) {
+ * 		char         *line  = i.key;
+ * 		struct tally *tally = i.value;
+ * 		
+ * 		printf("% 5ld: %s\n", tally->count, line);
+ * 		
+ * 		free(line);
+ * 		free(tally);
+ * 	}
+ * 	
+ * 	avl_free(avl);
+ * 	
+ * 	return 0;
+ * }
+ *
+ * Author: Joey Adams <joeyadams3.14159@gmail.com>
+ * License: MIT
+ * Version: 0.1
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/order\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/third_party/ccan/avl/avl.c
+++ b/third_party/ccan/avl/avl.c
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C) 2010 Joseph Adams <joeyadams3.14159@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "avl.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+static AvlNode *mkNode(const void *key, const void *value);
+static void freeNode(AvlNode *node);
+
+static AvlNode *lookup(const AVL *avl, AvlNode *node, const void *key);
+
+static bool insert(AVL *avl, AvlNode **p, const void *key, const void *value);
+static bool remove(AVL *avl, AvlNode **p, const void *key, AvlNode **ret);
+static bool removeExtremum(AvlNode **p, int side, AvlNode **ret);
+
+static int sway(AvlNode **p, int sway);
+static void balance(AvlNode **p, int side);
+
+static bool checkBalances(AvlNode *node, int *height);
+static bool checkOrder(AVL *avl);
+static size_t countNode(AvlNode *node);
+
+/*
+ * Utility macros for converting between
+ * "balance" values (-1 or 1) and "side" values (0 or 1).
+ *
+ * bal(0)   == -1
+ * bal(1)   == +1
+ * side(-1) == 0
+ * side(+1) == 1
+ */
+#define bal(side) ((side) == 0 ? -1 : 1)
+#define side(bal) ((bal)  == 1 ?  1 : 0)
+
+static int sign(int cmp)
+{
+	if (cmp < 0)
+		return -1;
+	if (cmp == 0)
+		return 0;
+	return 1;
+}
+
+AVL *avl_new(total_order_noctx_cb compare)
+{
+	AVL *avl = malloc(sizeof(*avl));
+	
+	assert(avl != NULL);
+	
+	avl->compare = compare;
+	avl->root = NULL;
+	avl->count = 0;
+	return avl;
+}
+
+void avl_free(AVL *avl)
+{
+	freeNode(avl->root);
+	free(avl);
+}
+
+void *avl_lookup(const AVL *avl, const void *key)
+{
+	AvlNode *found = lookup(avl, avl->root, key);
+	return found ? (void*) found->value : NULL;
+}
+
+AvlNode *avl_lookup_node(const AVL *avl, const void *key)
+{
+	return lookup(avl, avl->root, key);
+}
+
+size_t avl_count(const AVL *avl)
+{
+	return avl->count;
+}
+
+bool avl_insert(AVL *avl, const void *key, const void *value)
+{
+	size_t old_count = avl->count;
+	insert(avl, &avl->root, key, value);
+	return avl->count != old_count;
+}
+
+bool avl_remove(AVL *avl, const void *key)
+{
+	AvlNode *node = NULL;
+	
+	remove(avl, &avl->root, key, &node);
+	
+	if (node == NULL) {
+		return false;
+	} else {
+		free(node);
+		return true;
+	}
+}
+
+static AvlNode *mkNode(const void *key, const void *value)
+{
+	AvlNode *node = malloc(sizeof(*node));
+	
+	assert(node != NULL);
+	
+	node->key = key;
+	node->value = value;
+	node->lr[0] = NULL;
+	node->lr[1] = NULL;
+	node->balance = 0;
+	return node;
+}
+
+static void freeNode(AvlNode *node)
+{
+	if (node) {
+		freeNode(node->lr[0]);
+		freeNode(node->lr[1]);
+		free(node);
+	}
+}
+
+static AvlNode *lookup(const AVL *avl, AvlNode *node, const void *key)
+{
+	int cmp;
+	
+	if (node == NULL)
+		return NULL;
+	
+	cmp = avl->compare(key, node->key);
+	
+	if (cmp < 0)
+		return lookup(avl, node->lr[0], key);
+	if (cmp > 0)
+		return lookup(avl, node->lr[1], key);
+	return node;
+}
+
+/*
+ * Insert a key/value into a subtree, rebalancing if necessary.
+ *
+ * Return true if the subtree's height increased.
+ */
+static bool insert(AVL *avl, AvlNode **p, const void *key, const void *value)
+{
+	if (*p == NULL) {
+		*p = mkNode(key, value);
+		avl->count++;
+		return true;
+	} else {
+		AvlNode *node = *p;
+		int      cmp  = sign(avl->compare(key, node->key));
+		
+		if (cmp == 0) {
+			node->key = key;
+			node->value = value;
+			return false;
+		}
+		
+		if (!insert(avl, &node->lr[side(cmp)], key, value))
+			return false;
+		
+		/* If tree's balance became -1 or 1, it means the tree's height grew due to insertion. */
+		return sway(p, cmp) != 0;
+	}
+}
+
+/*
+ * Remove the node matching the given key.
+ * If present, return the removed node through *ret .
+ * The returned node's lr and balance are meaningless.
+ *
+ * Return true if the subtree's height decreased.
+ */
+static bool remove(AVL *avl, AvlNode **p, const void *key, AvlNode **ret)
+{
+	if (*p == NULL) {
+		return false;
+	} else {
+		AvlNode *node = *p;
+		int      cmp  = sign(avl->compare(key, node->key));
+		
+		if (cmp == 0) {
+			*ret = node;
+			avl->count--;
+			
+			if (node->lr[0] != NULL && node->lr[1] != NULL) {
+				AvlNode *replacement;
+				int      side;
+				bool     shrunk;
+				
+				/* Pick a subtree to pull the replacement from such that
+				 * this node doesn't have to be rebalanced. */
+				side = node->balance <= 0 ? 0 : 1;
+				
+				shrunk = removeExtremum(&node->lr[side], 1 - side, &replacement);
+				
+				replacement->lr[0]   = node->lr[0];
+				replacement->lr[1]   = node->lr[1];
+				replacement->balance = node->balance;
+				*p = replacement;
+				
+				if (!shrunk)
+					return false;
+				
+				replacement->balance -= bal(side);
+				
+				/* If tree's balance became 0, it means the tree's height shrank due to removal. */
+				return replacement->balance == 0;
+			}
+			
+			if (node->lr[0] != NULL)
+				*p = node->lr[0];
+			else
+				*p = node->lr[1];
+			
+			return true;
+			
+		} else {
+			if (!remove(avl, &node->lr[side(cmp)], key, ret))
+				return false;
+			
+			/* If tree's balance became 0, it means the tree's height shrank due to removal. */
+			return sway(p, -cmp) == 0;
+		}
+	}
+}
+
+/*
+ * Remove either the left-most (if side == 0) or right-most (if side == 1)
+ * node in a subtree, returning the removed node through *ret .
+ * The returned node's lr and balance are meaningless.
+ *
+ * The subtree must not be empty (i.e. *p must not be NULL).
+ *
+ * Return true if the subtree's height decreased.
+ */
+static bool removeExtremum(AvlNode **p, int side, AvlNode **ret)
+{
+	AvlNode *node = *p;
+	
+	if (node->lr[side] == NULL) {
+		*ret = node;
+		*p = node->lr[1 - side];
+		return true;
+	}
+	
+	if (!removeExtremum(&node->lr[side], side, ret))
+		return false;
+	
+	/* If tree's balance became 0, it means the tree's height shrank due to removal. */
+	return sway(p, -bal(side)) == 0;
+}
+
+/*
+ * Rebalance a node if necessary.  Think of this function
+ * as a higher-level interface to balance().
+ *
+ * sway must be either -1 or 1, and indicates what was added to
+ * the balance of this node by a prior operation.
+ *
+ * Return the new balance of the subtree.
+ */
+static int sway(AvlNode **p, int sway)
+{
+	if ((*p)->balance != sway)
+		(*p)->balance += sway;
+	else
+		balance(p, side(sway));
+	
+	return (*p)->balance;
+}
+
+/*
+ * Perform tree rotations on an unbalanced node.
+ *
+ * side == 0 means the node's balance is -2 .
+ * side == 1 means the node's balance is +2 .
+ */
+static void balance(AvlNode **p, int side)
+{
+	AvlNode  *node  = *p,
+	         *child = node->lr[side];
+	int opposite    = 1 - side;
+	int bal         = bal(side);
+	
+	if (child->balance != -bal) {
+		/* Left-left (side == 0) or right-right (side == 1) */
+		node->lr[side]      = child->lr[opposite];
+		child->lr[opposite] = node;
+		*p = child;
+		
+		child->balance -= bal;
+		node->balance = -child->balance;
+		
+	} else {
+		/* Left-right (side == 0) or right-left (side == 1) */
+		AvlNode *grandchild = child->lr[opposite];
+		
+		node->lr[side]           = grandchild->lr[opposite];
+		child->lr[opposite]      = grandchild->lr[side];
+		grandchild->lr[side]     = child;
+		grandchild->lr[opposite] = node;
+		*p = grandchild;
+		
+		node->balance       = 0;
+		child->balance      = 0;
+		
+		if (grandchild->balance == bal)
+			node->balance  = -bal;
+		else if (grandchild->balance == -bal)
+			child->balance = bal;
+		
+		grandchild->balance = 0;
+	}
+}
+
+
+/************************* avl_check_invariants() *************************/
+
+bool avl_check_invariants(AVL *avl)
+{
+	int    dummy;
+	
+	return checkBalances(avl->root, &dummy)
+	    && checkOrder(avl)
+	    && countNode(avl->root) == avl->count;
+}
+
+static bool checkBalances(AvlNode *node, int *height)
+{
+	if (node) {
+		int h0, h1;
+		
+		if (!checkBalances(node->lr[0], &h0))
+			return false;
+		if (!checkBalances(node->lr[1], &h1))
+			return false;
+		
+		if (node->balance != h1 - h0 || node->balance < -1 || node->balance > 1)
+			return false;
+		
+		*height = (h0 > h1 ? h0 : h1) + 1;
+		return true;
+	} else {
+		*height = 0;
+		return true;
+	}
+}
+
+static bool checkOrder(AVL *avl)
+{
+	AvlIter     i;
+	const void *last     = NULL;
+	bool        last_set = false;
+	
+	avl_foreach(i, avl) {
+		if (last_set && avl->compare(last, i.key) >= 0)
+			return false;
+		last     = i.key;
+		last_set = true;
+	}
+	
+	return true;
+}
+
+static size_t countNode(AvlNode *node)
+{
+	if (node)
+		return 1 + countNode(node->lr[0]) + countNode(node->lr[1]);
+	else
+		return 0;
+}
+
+
+/************************* Traversal *************************/
+
+void avl_iter_begin(AvlIter *iter, AVL *avl, AvlDirection dir)
+{
+	AvlNode *node = avl->root;
+	
+	iter->stack_index = 0;
+	iter->direction   = dir;
+	
+	if (node == NULL) {
+		iter->key      = NULL;
+		iter->value    = NULL;
+		iter->node     = NULL;
+		return;
+	}
+	
+	while (node->lr[dir] != NULL) {
+		iter->stack[iter->stack_index++] = node;
+		node = node->lr[dir];
+	}
+	
+	iter->key   = (void*) node->key;
+	iter->value = (void*) node->value;
+	iter->node  = node;
+}
+
+void avl_iter_next(AvlIter *iter)
+{
+	AvlNode     *node = iter->node;
+	AvlDirection dir  = iter->direction;
+	
+	if (node == NULL)
+		return;
+	
+	node = node->lr[1 - dir];
+	if (node != NULL) {
+		while (node->lr[dir] != NULL) {
+			iter->stack[iter->stack_index++] = node;
+			node = node->lr[dir];
+		}
+	} else if (iter->stack_index > 0) {
+		node = iter->stack[--iter->stack_index];
+	} else {
+		iter->key      = NULL;
+		iter->value    = NULL;
+		iter->node     = NULL;
+		return;
+	}
+	
+	iter->node  = node;
+	iter->key   = (void*) node->key;
+	iter->value = (void*) node->value;
+}

--- a/third_party/ccan/avl/avl.h
+++ b/third_party/ccan/avl/avl.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2010 Joseph Adams <joeyadams3.14159@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CCAN_AVL_H
+#define CCAN_AVL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include <ccan/order/order.h>
+
+typedef struct AVL           AVL;
+typedef struct AvlNode       AvlNode;
+typedef struct AvlIter       AvlIter;
+
+AVL *avl_new(total_order_noctx_cb compare);
+	/* Create a new AVL tree sorted with the given comparison function. */
+
+void avl_free(AVL *avl);
+	/* Free an AVL tree. */
+
+void *avl_lookup(const AVL *avl, const void *key);
+	/* O(log n). Lookup a value at a key.  Return NULL if the key is not present. */
+
+#define avl_member(avl, key) (!!avl_lookup_node(avl, key))
+	/* O(log n). See if a key is present. */
+
+size_t avl_count(const AVL *avl);
+	/* O(1). Return the number of elements in the tree. */
+
+bool avl_insert(AVL *avl, const void *key, const void *value);
+	/*
+	 * O(log n). Insert a key/value pair, or replace it if already present.
+	 *
+	 * Return false if the insertion replaced an existing key/value.
+	 */
+
+bool avl_remove(AVL *avl, const void *key);
+	/*
+	 * O(log n). Remove a key/value pair (if present).
+	 *
+	 * Return true if it was removed.
+	 */
+
+bool avl_check_invariants(AVL *avl);
+	/* For testing purposes.  This function will always return true :-) */
+
+
+/************************* Traversal *************************/
+
+#define avl_foreach(iter, avl)         avl_traverse(iter, avl, FORWARD)
+	/*
+	 * O(n). Traverse an AVL tree in order.
+	 *
+	 * Example:
+	 *
+	 * AvlIter i;
+	 *
+	 * avl_foreach(i, avl)
+	 *     printf("%s -> %s\n", i.key, i.value);
+	 */
+
+#define avl_foreach_reverse(iter, avl) avl_traverse(iter, avl, BACKWARD)
+	/* O(n). Traverse an AVL tree in reverse order. */
+
+typedef enum AvlDirection {FORWARD = 0, BACKWARD = 1} AvlDirection;
+
+struct AvlIter {
+	void         *key;
+	void         *value;
+	AvlNode      *node;
+	
+	/* private */
+	AvlNode      *stack[100];
+	int           stack_index;
+	AvlDirection  direction;
+};
+
+void avl_iter_begin(AvlIter *iter, AVL *avl, AvlDirection dir);
+void avl_iter_next(AvlIter *iter);
+#define avl_traverse(iter, avl, direction)        \
+	for (avl_iter_begin(&(iter), avl, direction); \
+	     (iter).node != NULL;                     \
+	     avl_iter_next(&iter))
+
+
+/***************** Internal data structures ******************/
+
+struct AVL {
+	total_order_noctx_cb compare;
+	AvlNode    *root;
+	size_t      count;
+};
+
+struct AvlNode {
+	const void *key;
+	const void *value;
+	
+	AvlNode    *lr[2];
+	int         balance; /* -1, 0, or 1 */
+};
+
+AvlNode *avl_lookup_node(const AVL *avl, const void *key);
+	/* O(log n). Lookup an AVL node by key.  Return NULL if not present. */
+
+#endif

--- a/third_party/ccan/avl/test/run.c
+++ b/third_party/ccan/avl/test/run.c
@@ -1,0 +1,481 @@
+/*
+ * Copyright (C) 2010 Joseph Adams <joeyadams3.14159@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <ccan/avl/avl.h>
+
+#define remove remove_
+#include <ccan/avl/avl.c>
+#undef remove
+
+#include <ccan/tap/tap.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ANIMATE_RANDOM_ACCESS 0
+
+#if ANIMATE_RANDOM_ACCESS
+
+#include <sys/time.h>
+
+typedef int64_t msec_t;
+
+static msec_t time_ms(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return (msec_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+#endif
+
+uint32_t rand32_state = 0;
+
+/*
+ * Finds a pseudorandom 32-bit number from 0 to 2^32-1 .
+ * Uses the BCPL linear congruential generator method.
+ *
+ * Note: this method (or maybe just this implementation) seems to
+ *       go back and forth between odd and even exactly, which can
+ *       affect low-cardinality testing if the cardinality given is even.
+ */
+static uint32_t rand32(void)
+{
+	rand32_state *= (uint32_t)0x7FF8A3ED;
+	rand32_state += (uint32_t)0x2AA01D31;
+	return rand32_state;
+}
+
+static void scramble(void *base, size_t nmemb, size_t size)
+{
+	char *i = base;
+	char *o;
+	size_t sd;
+	for (;nmemb>1;nmemb--) {
+		o = i + size*(rand32()%nmemb);
+		for (sd=size;sd--;) {
+			char tmp = *o;
+			*o++ = *i;
+			*i++ = tmp;
+		}
+	}
+}
+
+static struct {
+	size_t success;
+	size_t passed_invariants_checks;
+	
+	size_t excess;
+	size_t duplicate;
+	size_t missing;
+	size_t incorrect;
+	size_t failed;
+	size_t failed_invariants_checks;
+} stats;
+
+static void clear_stats(void)
+{
+	memset(&stats, 0, sizeof(stats));
+}
+
+static bool print_stats(const char *success_label, size_t expected_success)
+{
+	int failed = 0;
+	
+	printf("      %s:  \t%zu\n", success_label, stats.success);
+	if (stats.success != expected_success)
+		failed = 1;
+	
+	if (stats.passed_invariants_checks)
+		printf("      Passed invariants checks: %zu\n", stats.passed_invariants_checks);
+	
+	if (stats.excess)
+		failed = 1, printf("      Excess:     \t%zu\n", stats.excess);
+	if (stats.duplicate)
+		failed = 1, printf("      Duplicate:  \t%zu\n", stats.duplicate);
+	if (stats.missing)
+		failed = 1, printf("      Missing:    \t%zu\n", stats.missing);
+	if (stats.incorrect)
+		failed = 1, printf("      Incorrect:  \t%zu\n", stats.incorrect);
+	if (stats.failed)
+		failed = 1, printf("      Failed:     \t%zu\n", stats.failed);
+	if (stats.failed_invariants_checks)
+		failed = 1, printf("      Failed invariants checks: %zu\n", stats.failed_invariants_checks);
+	
+	return !failed;
+}
+
+struct test_item {
+	uint32_t key;
+	uint32_t value;
+	size_t   insert_id; /* needed because qsort is not a stable sort */
+};
+
+static int compare_test_item(const void *ap, const void *bp)
+{
+	const struct test_item *a = *(void**)ap, *b = *(void**)bp;
+	
+	if (a->key < b->key)
+		return -1;
+	if (a->key > b->key)
+		return 1;
+	
+	if (a->insert_id < b->insert_id)
+		return -1;
+	if (a->insert_id > b->insert_id)
+		return 1;
+	
+	return 0;
+}
+
+static bool test_insert_item(AVL *avl, struct test_item *item)
+{
+	avl_insert(avl, &item->key, &item->value);
+	return true;
+}
+
+static bool test_lookup_item(const AVL *avl, const struct test_item *item)
+{
+	return avl_member(avl, &item->key) && avl_lookup(avl, &item->key) == &item->value;
+}
+
+static bool test_remove_item(AVL *avl, struct test_item *item)
+{
+	return avl_remove(avl, &item->key);
+}
+
+static void test_foreach(AVL *avl, struct test_item **test_items, int count)
+{
+	AvlIter iter;
+	int     i;
+	
+	i = 0;
+	avl_foreach(iter, avl) {
+		if (i >= count) {
+			stats.excess++;
+			continue;
+		}
+		if (iter.key == &test_items[i]->key && iter.value == &test_items[i]->value)
+			stats.success++;
+		else
+			stats.incorrect++;
+		i++;
+	}
+}
+
+static void test_foreach_reverse(AVL *avl, struct test_item **test_items, int count)
+{
+	AvlIter iter;
+	int     i;
+	
+	i = count - 1;
+	avl_foreach_reverse(iter, avl) {
+		if (i < 0) {
+			stats.excess++;
+			continue;
+		}
+		if (iter.key == &test_items[i]->key && iter.value == &test_items[i]->value)
+			stats.success++;
+		else
+			stats.incorrect++;
+		i--;
+	}
+}
+
+static void benchmark(size_t max_per_trial, size_t round_count, bool random_counts, int cardinality)
+{
+	struct test_item **test_item;
+	struct test_item *test_item_array;
+	size_t i, o, count;
+	size_t round = 0;
+	
+	test_item = malloc(max_per_trial * sizeof(*test_item));
+	test_item_array = malloc(max_per_trial * sizeof(*test_item_array));
+	
+	if (!test_item || !test_item_array) {
+		fail("Not enough memory for %zu keys per trial\n",
+			max_per_trial);
+		return;
+	}
+	
+	/* Initialize test_item pointers. */
+	for (i=0; i<max_per_trial; i++)
+		test_item[i] = &test_item_array[i];
+	
+	/*
+	 * If round_count is not zero, run round_count trials.
+	 * Otherwise, run forever.
+	 */
+	for (round = 1; round_count==0 || round <= round_count; round++) {
+		AVL *avl;
+		
+		if (cardinality)
+			printf("Round %zu (cardinality = %d)\n", round, cardinality);
+		else
+			printf("Round %zu\n", round);
+		
+		if (random_counts)
+			count = rand32() % (max_per_trial+1);
+		else
+			count = max_per_trial;
+		
+		/*
+		 * Initialize test items by giving them sequential keys and
+		 * random values. Scramble them so the order of insertion
+		 * will be random.
+		 */
+		for (i=0; i<count; i++) {
+			test_item[i]->key   = rand32();
+			test_item[i]->value = rand32();
+			
+			if (cardinality)
+				test_item[i]->key %= cardinality;
+		}
+		scramble(test_item, count, sizeof(*test_item));
+		
+		avl = avl_new(order_u32_noctx);
+		
+		clear_stats();
+		printf("   Inserting %zu items...\n", count);
+		for (i=0; i<count; i++) {
+			if (test_insert_item(avl, test_item[i])) {
+				stats.success++;
+				test_item[i]->insert_id = i;
+			} else {
+				printf("invariants check failed at insertion %zu\n", i);
+				stats.failed++;
+			}
+			
+			/* Periodically do an invariants check */
+			if (count / 10 > 0 && i % (count / 10) == 0) {
+				if (avl_check_invariants(avl))
+					stats.passed_invariants_checks++;
+				else
+					stats.failed_invariants_checks++;
+			}
+		}
+		ok1(print_stats("Inserted", count));
+		ok1(avl_check_invariants(avl));
+		
+		/* remove early duplicates, as they are shadowed in insertions. */
+		qsort(test_item, count, sizeof(*test_item), compare_test_item);
+		for (i = 0, o = 0; i < count;) {
+			uint32_t k = test_item[i]->key;
+			do i++; while (i < count && test_item[i]->key == k);
+			test_item[o++] = test_item[i-1];
+		}
+		count = o;
+		ok1(avl_count(avl) == count);
+		
+		scramble(test_item, count, sizeof(*test_item));
+		
+		printf("   Finding %zu items...\n", count);
+		clear_stats();
+		for (i=0; i<count; i++) {
+			if (!test_lookup_item(avl, test_item[i]))
+				stats.missing++;
+			else
+				stats.success++;
+		}
+		ok1(print_stats("Retrieved", count));
+		
+		qsort(test_item, count, sizeof(*test_item), compare_test_item);
+		
+		printf("   Traversing forward through %zu items...\n", count);
+		clear_stats();
+		test_foreach(avl, test_item, count);
+		ok1(print_stats("Traversed", count));
+		
+		printf("   Traversing backward through %zu items...\n", count);
+		clear_stats();
+		test_foreach_reverse(avl, test_item, count);
+		ok1(print_stats("Traversed", count));
+		
+		scramble(test_item, count, sizeof(*test_item));
+		
+		printf("   Deleting %zu items...\n", count);
+		clear_stats();
+		for (i=0; i<count; i++) {
+			if (test_remove_item(avl, test_item[i]))
+				stats.success++;
+			else
+				stats.missing++;
+			
+			/* Periodically do an invariants check */
+			if (count / 10 > 0 && i % (count / 10) == 0) {
+				if (avl_check_invariants(avl))
+					stats.passed_invariants_checks++;
+				else
+					stats.failed_invariants_checks++;
+			}
+		}
+		ok1(print_stats("Deleted", count));
+		ok1(avl_count(avl) == 0);
+		ok1(avl_check_invariants(avl));
+		
+		avl_free(avl);
+	}
+	
+	free(test_item);
+	free(test_item_array);
+}
+
+static int compare_ptr(const void *a, const void *b)
+{
+	if (a < b)
+		return -1;
+	if (a > b)
+		return 1;
+	return 0;
+}
+
+struct fail_total {
+	int64_t fail;
+	int64_t total;
+};
+
+static bool print_pass_fail(struct fail_total *pf, const char *label)
+{
+	long long fail  = pf->fail,
+	          total = pf->total;
+	
+	printf("%s:\t%lld / %lld\n", label, total - fail, total);
+	
+	return fail == 0;
+}
+
+static void test_random_access(uint32_t max, int64_t ops)
+{
+	char       *in_tree;
+	AVL        *avl;
+	int64_t     i;
+	struct {
+		struct fail_total
+			inserts, lookups, removes, checks;
+	} s;
+	
+	#if ANIMATE_RANDOM_ACCESS
+	msec_t last_update, now;
+	msec_t interval = 100;
+	#endif
+	
+	memset(&s, 0, sizeof(s));
+	
+	in_tree = malloc(max);
+	memset(in_tree, 0, max);
+	
+	avl = avl_new(compare_ptr);
+	
+	#if ANIMATE_RANDOM_ACCESS
+	now = time_ms();
+	last_update = now - interval;
+	#endif
+	
+	for (i = 0; i < ops; i++) {
+		char *item = &in_tree[rand32() % max];
+		char *found;
+		bool  inserted, removed;
+		
+		#if ANIMATE_RANDOM_ACCESS
+		now = time_ms();
+		if (now >= last_update + interval) {
+			last_update = now;
+			printf("\r%.2f%%\t%zu / %zu\033[K", (double)i * 100 / ops, avl_count(avl), max);
+			fflush(stdout);
+		}
+		#endif
+		
+		switch (rand32() % 3) {
+			case 0:
+				inserted = avl_insert(avl, item, item);
+				
+				if ((*item == 0 && !inserted) ||
+				    (*item == 1 && inserted))
+					s.inserts.fail++;
+				
+				if (inserted)
+					*item = 1;
+				
+				s.inserts.total++;
+				break;
+			
+			case 1:
+				found = avl_lookup(avl, item);
+				
+				if ((*item == 0 && found != NULL) ||
+				    (*item == 1 && found != item) ||
+				    (avl_member(avl, item) != !!found))
+					s.lookups.fail++;
+				
+				s.lookups.total++;
+				break;
+			
+			case 2:
+				removed = avl_remove(avl, item);
+				
+				if ((*item == 0 && removed) ||
+				    (*item == 1 && !removed))
+					s.removes.fail++;
+				
+				if (removed)
+					*item = 0;
+				
+				s.removes.total++;
+				break;
+		}
+		
+		/* Periodically do an invariants check */
+		if (ops / 10 > 0 && i % (ops / 10) == 0) {
+			if (!avl_check_invariants(avl))
+				s.checks.fail++;
+			s.checks.total++;
+		}
+	}
+	
+	#if ANIMATE_RANDOM_ACCESS
+	printf("\r\033[K");
+	#endif
+	
+	avl_free(avl);
+	free(in_tree);
+	
+	ok1(print_pass_fail(&s.inserts, "Inserts"));
+	ok1(print_pass_fail(&s.lookups, "Lookups"));
+	ok1(print_pass_fail(&s.removes, "Removes"));
+	ok1(print_pass_fail(&s.checks,  "Invariants checks"));
+}
+
+int main(void)
+{
+	plan_tests(18 * 3 + 4);
+	
+	benchmark(100000, 2, false, 0);
+	benchmark(100000, 2, false, 12345);
+	benchmark(100000, 2, false, 100001);
+	
+	printf("Running random access test\n");
+	test_random_access(12345, 1234567);
+	
+	return exit_status();
+}

--- a/third_party/ccan/order/LICENSE
+++ b/third_party/ccan/order/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/third_party/ccan/order/_info
+++ b/third_party/ccan/order/_info
@@ -1,0 +1,33 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * order - Simple, common value comparison functions
+ *
+ * This implements a number of commonly useful comparison functions in
+ * a form which can be used with qsort() and bsearch() in the standard
+ * library, or asort() and asearch() in ccan amongst other places.
+ *
+ * License: CC0
+ * Author: David Gibson <david@gibson.dropbear.id.au>
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/typesafe_cb\n");
+		printf("ccan/ptrint\n");
+		return 0;
+	}
+	if (strcmp(argv[1], "testdepends") == 0) {
+		printf("ccan/array_size\n");
+		printf("ccan/asort\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/third_party/ccan/order/order.c
+++ b/third_party/ccan/order/order.c
@@ -1,0 +1,70 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+
+#include <ccan/order/order.h>
+
+#define SCALAR_ORDER(_oname, _type)					\
+	int _order_##_oname(const void *a,				\
+			    const void *b,				\
+			    void *ctx)					\
+	{								\
+		ptrdiff_t offset = ptr2int(ctx);			\
+		const _type *aa = (const _type *)((char *)a + offset);	\
+		const _type *bb = (const _type *)((char *)b + offset);	\
+									\
+		if (*aa < *bb) {					\
+			return -1;					\
+		} else if (*aa > *bb) {					\
+			return 1;					\
+		} else {						\
+			assert(*aa == *bb);				\
+			return 0;					\
+		}							\
+	}								\
+	int order_##_oname(const _type *a,				\
+			   const _type *b,				\
+			   void *ctx)					\
+	{								\
+		return _order_##_oname(a, b, int2ptr(0));		\
+	}								\
+	int _order_##_oname##_reverse(const void *a,			\
+				      const void *b,			\
+				      void *ctx)			\
+	{								\
+		return -_order_##_oname(a, b, ctx);			\
+	}								\
+	int order_##_oname##_reverse(const _type *a,			\
+				     const _type *b,			\
+				     void *ctx)				\
+	{								\
+		return _order_##_oname##_reverse(a, b, int2ptr(0));	\
+	}								\
+	int order_##_oname##_noctx(const void *a,			\
+				   const void *b)			\
+	{								\
+		return _order_##_oname(a, b, int2ptr(0));		\
+	}								\
+	int order_##_oname##_reverse_noctx(const void *a,		\
+					   const void *b)		\
+	{								\
+		return _order_##_oname##_reverse(a, b, int2ptr(0));	\
+	}
+
+SCALAR_ORDER(s8, int8_t)
+SCALAR_ORDER(s16, int16_t)
+SCALAR_ORDER(s32, int32_t)
+SCALAR_ORDER(s64, int64_t)
+
+SCALAR_ORDER(u8, uint8_t)
+SCALAR_ORDER(u16, uint16_t)
+SCALAR_ORDER(u32, uint32_t)
+SCALAR_ORDER(u64, uint64_t)
+
+SCALAR_ORDER(int, int)
+SCALAR_ORDER(uint, unsigned int)
+SCALAR_ORDER(long, long)
+SCALAR_ORDER(ulong, unsigned long)
+SCALAR_ORDER(size, size_t)
+SCALAR_ORDER(ptrdiff, ptrdiff_t)
+
+SCALAR_ORDER(float, float)
+SCALAR_ORDER(double, double)

--- a/third_party/ccan/order/order.h
+++ b/third_party/ccan/order/order.h
@@ -1,0 +1,76 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#ifndef CCAN_ORDER_H
+#define CCAN_ORDER_H
+
+#include <stdint.h>
+#include <assert.h>
+
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <ccan/ptrint/ptrint.h>
+
+typedef int (*_total_order_cb)(const void *, const void *, void *);
+typedef int (*total_order_noctx_cb)(const void *, const void *);
+
+#define total_order_cb(_name, _item, _ctx)		\
+	int (*_name)(const __typeof__(_item) *,		\
+		     const __typeof__(_item) *,		\
+		     __typeof__(_ctx))
+
+#define total_order_cast(cmp, item, ctx)				\
+	typesafe_cb_cast(_total_order_cb, total_order_cb(, item, ctx),	\
+			 (cmp))
+
+struct _total_order {
+	_total_order_cb cb;
+	void *ctx;
+};
+
+#define total_order(_name, _item, _ctx)			\
+	struct {					\
+		total_order_cb(cb, _item, _ctx);	\
+		_ctx ctx;				\
+	} _name
+
+#define total_order_cmp(_order, _a, _b)					\
+	((_order).cb((_a), (_b), (_order).ctx))
+
+#define _DECL_ONAME(_oname, _itype)					\
+	extern int _order_##_oname(const void *, const void *, void *);	\
+	extern int order_##_oname(const _itype *, const _itype *, void *); \
+	extern int order_##_oname##_noctx(const void *, const void *);
+
+#define _DECL_ONAME_BIDIR(_oname, _itype)				\
+	_DECL_ONAME(_oname, _itype)					\
+	_DECL_ONAME(_oname##_reverse, _itype)
+
+_DECL_ONAME_BIDIR(s8, int8_t)
+_DECL_ONAME_BIDIR(s16, int16_t)
+_DECL_ONAME_BIDIR(s32, int32_t)
+_DECL_ONAME_BIDIR(s64, int64_t)
+
+_DECL_ONAME_BIDIR(u8, uint8_t)
+_DECL_ONAME_BIDIR(u16, uint16_t)
+_DECL_ONAME_BIDIR(u32, uint32_t)
+_DECL_ONAME_BIDIR(u64, uint64_t)
+
+_DECL_ONAME_BIDIR(int, int)
+_DECL_ONAME_BIDIR(uint, unsigned int)
+_DECL_ONAME_BIDIR(long, long)
+_DECL_ONAME_BIDIR(ulong, unsigned long)
+_DECL_ONAME_BIDIR(size, size_t)
+_DECL_ONAME_BIDIR(ptrdiff, ptrdiff_t)
+
+_DECL_ONAME_BIDIR(float, float)
+_DECL_ONAME_BIDIR(double, double)
+
+#undef _DECL_ONAME
+#undef _DECL_ONAME_BIDIR
+
+#define total_order_by_field(_name, _oname, _itype, _field)		\
+	total_order(_name, _itype, ptrint_t *) = {			\
+		(total_order_cb(, _itype,				\
+				ptrint_t *))(_order_##_oname),		\
+		int2ptr(offsetof(_itype, _field)),			\
+	}
+
+#endif /* CCAN_ORDER_H */

--- a/third_party/ccan/order/test/api.c
+++ b/third_party/ccan/order/test/api.c
@@ -1,0 +1,138 @@
+#include "config.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <float.h>
+#include <math.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include <ccan/order/order.h>
+#include <ccan/tap/tap.h>
+
+#include <ccan/asort/asort.h>
+
+#define QSORT_SCALAR(t, oname, ...)					\
+	{								\
+		t arr0[] = { __VA_ARGS__ };				\
+		const int num = ARRAY_SIZE(arr0);			\
+		t arr1[num], arr2[num];					\
+		int i;							\
+									\
+		/* Intialize arr1 in reverse order */			\
+		for (i = 0; i < num; i++)				\
+			arr1[i] = arr0[num-i-1];			\
+									\
+		memcpy(arr2, arr1, sizeof(arr1));			\
+		qsort(arr2, num, sizeof(t), order_##oname##_noctx);	\
+		ok(memcmp(arr2, arr0, sizeof(arr0)) == 0,		\
+		   "qsort order_%s_noctx", #oname);			\
+									\
+		qsort(arr2, num, sizeof(t), order_##oname##_reverse_noctx); \
+		ok(memcmp(arr2, arr1, sizeof(arr1)) == 0,		\
+		   "qsort order_%s_reverse_noctx", #oname);		\
+	}
+
+#define ASORT_SCALAR(t, oname, ...)					\
+	{								\
+		t arr0[] = { __VA_ARGS__ };				\
+		const int num = ARRAY_SIZE(arr0);			\
+		t arr1[num], arr2[num];					\
+		int i;							\
+									\
+		/* Intialize arr1 in reverse order */			\
+		for (i = 0; i < num; i++)				\
+			arr1[i] = arr0[num-i-1];			\
+									\
+		memcpy(arr2, arr1, sizeof(arr1));			\
+		asort(arr2, num, order_##oname, NULL);			\
+		ok(memcmp(arr2, arr0, sizeof(arr0)) == 0,		\
+		   "asort order_%s", #oname);				\
+									\
+		asort(arr2, num, order_##oname##_reverse, NULL);	\
+		ok(memcmp(arr2, arr1, sizeof(arr1)) == 0,		\
+		   "asort order_%s_reverse", #oname);			\
+	}
+
+#define ASORT_STRUCT_BY_SCALAR(t, oname, ...)				\
+	{								\
+		t arrbase[] = { __VA_ARGS__ };				\
+		struct tstruct {					\
+			char dummy0[5];					\
+			t val;						\
+			long dummy1;					\
+		};							\
+		const int num = ARRAY_SIZE(arrbase);			\
+		struct tstruct arr0[num], arr1[num], arr2[num];		\
+		int i;							\
+		total_order_by_field(order, oname, struct tstruct, val); \
+		total_order_by_field(rorder, oname##_reverse,		\
+				     struct tstruct, val);		\
+									\
+		/* Set up dummy structures */				\
+		memset(arr0, 0, sizeof(arr0));				\
+		for (i = 0; i < num; i++) {				\
+			arr0[i].dummy1 = i;				\
+			strcpy(arr0[i].dummy0, "abc");			\
+			arr0[i].val = arrbase[i];			\
+		}							\
+									\
+		/* Intialize arr1 in reverse order */			\
+		for (i = 0; i < num; i++)				\
+			arr1[i] = arr0[num-i-1];			\
+									\
+		memcpy(arr2, arr1, sizeof(arr1));			\
+		asort(arr2, num, order.cb, order.ctx);			\
+		ok(memcmp(arr2, arr0, sizeof(arr0)) == 0,		\
+		   "asort by field %s", #oname);			\
+									\
+		asort(arr2, num, rorder.cb, rorder.ctx);		\
+		ok(memcmp(arr2, arr1, sizeof(arr1)) == 0,		\
+		   "asort by field %s_reverse", #oname);		\
+	}
+
+#define TEST_SCALAR(t, oname, ...)					\
+	{								\
+		QSORT_SCALAR(t, oname, __VA_ARGS__);			\
+		ASORT_SCALAR(t, oname, __VA_ARGS__);			\
+		ASORT_STRUCT_BY_SCALAR(t, oname, __VA_ARGS__);		\
+	}
+
+int main(void)
+{
+	/* This is how many tests you plan to run */
+	plan_tests(84);
+
+	TEST_SCALAR(int8_t, s8, -128, -4, 0, 1, 2, 88, 126, 127);
+	TEST_SCALAR(int16_t, s16, -32768, -4, 0, 1, 2, 88, 126, 32767);
+	TEST_SCALAR(int32_t, s32, -2000000000, -4, 0, 1, 2, 88, 126,
+		    2000000000);
+	TEST_SCALAR(int64_t, s64, -999999999999999999LL, -2000000000, -4, 0,
+		    1, 2, 88, 126, 2000000000, 999999999999999999LL);
+
+	TEST_SCALAR(uint8_t, u8, 0, 1, 2, 88, 126, 127, -10, -1);
+	TEST_SCALAR(uint16_t, u16, 0, 1, 2, 88, 126, 32767, -10, -1);
+	TEST_SCALAR(uint32_t, u32, 0, 1, 2, 88, 126, 2000000000, -10, -1);
+	TEST_SCALAR(uint64_t, u64, 0, 1, 2, 88, 126, 2000000000,
+		    999999999999999999LL, -10, -1);
+
+	TEST_SCALAR(int, int, INT_MIN, -10, -1, 0, 1, 10, INT_MAX);
+	TEST_SCALAR(unsigned, uint, 0, 1, 10, INT_MAX, (unsigned)INT_MAX+1,
+		    -10, -1);
+
+	TEST_SCALAR(long, long, LONG_MIN, INT_MIN, -10, -1, 0, 1, 10, INT_MAX,
+		    LONG_MAX);
+	TEST_SCALAR(unsigned long, ulong, 0, 1, 10, INT_MAX,
+		    (unsigned long)INT_MAX+1, LONG_MAX,
+		    (unsigned long)LONG_MAX+1, -10, -1);
+
+	TEST_SCALAR(float, float, -INFINITY, -FLT_MAX, -1.0, 0.0, FLT_MIN,
+		  0.1, M_E, M_PI, 5.79, FLT_MAX, INFINITY);
+	TEST_SCALAR(double, double, -INFINITY, -DBL_MAX, -FLT_MAX, -1.0, 0.0,
+		  DBL_MIN, FLT_MIN, 0.1, M_E, M_PI, 5.79, FLT_MAX, DBL_MAX,
+		  INFINITY);
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/third_party/ccan/order/test/compile_fail_1.c
+++ b/third_party/ccan/order/test/compile_fail_1.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <ccan/order/order.h>
+
+#include "fancy_cmp.h"
+
+#ifdef FAIL
+typedef int item_t;
+#else
+typedef struct item item_t;
+#endif
+
+int main(int argc, char *argv[])
+{
+	total_order_cb(cb0, struct item, struct cmp_info *) = fancy_cmp;
+	_total_order_cb cb1 = total_order_cast(fancy_cmp,
+					       item_t, struct cmp_info *);
+
+	printf("%p %p\n", cb0, cb1);
+
+	exit(0);
+}

--- a/third_party/ccan/order/test/compile_fail_2.c
+++ b/third_party/ccan/order/test/compile_fail_2.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <ccan/order/order.h>
+
+#include "fancy_cmp.h"
+
+#ifdef FAIL
+typedef int ctx_t;
+#else
+typedef struct cmp_info ctx_t;
+#endif
+
+int main(int argc, char *argv[])
+{
+	total_order_cb(cb0, struct item, struct cmp_info *) = fancy_cmp;
+	_total_order_cb cb1 = total_order_cast(fancy_cmp, struct item,
+					       ctx_t *);
+
+	printf("%p %p\n", cb0, cb1);
+
+	exit(0);
+
+}

--- a/third_party/ccan/order/test/compile_ok.c
+++ b/third_party/ccan/order/test/compile_ok.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <ccan/order/order.h>
+
+#include "fancy_cmp.h"
+
+int main(int argc, char *argv[])
+{
+	total_order_cb(cb0, struct item, struct cmp_info *) = fancy_cmp;
+	_total_order_cb cb1 = total_order_cast(fancy_cmp,
+					       struct item, struct cmp_info *);
+	total_order_noctx_cb cb_noctx = fancy_cmp_noctx;
+
+	printf("%p %p %p\n", cb0, cb1, cb_noctx);
+
+	exit(0);
+}

--- a/third_party/ccan/order/test/fancy_cmp.h
+++ b/third_party/ccan/order/test/fancy_cmp.h
@@ -1,0 +1,47 @@
+#ifndef _FANCY_CMP_H
+#define _FANCY_CMP_H
+
+struct cmp_info {
+	unsigned xcode;
+	int offset;
+};
+
+struct item {
+	unsigned value;
+	const char *str;
+};
+
+static inline int fancy_cmp(const struct item *a, const struct item *b,
+			    struct cmp_info *ctx)
+{
+	unsigned vala = a->value ^ ctx->xcode;
+	unsigned valb = b->value ^ ctx->xcode;
+	const char *stra, *strb;
+
+	if (vala < valb)
+		return -1;
+	else if (valb < vala)
+		return 1;
+
+	stra = a->str + ctx->offset;
+	strb = b->str + ctx->offset;
+
+	return strcmp(stra, strb);
+}
+
+static inline int fancy_cmp_noctx(const void *av, const void *bv)
+{
+	const struct item *a = (const struct item *)av;
+	const struct item *b = (const struct item *)bv;
+	struct cmp_info ctx_default = {
+		.xcode = 0x1234,
+		.offset = 3,
+	};
+	total_order(default_order, struct item, struct cmp_info *) = {
+		fancy_cmp, &ctx_default,
+	};
+
+	return default_order.cb(a, b, default_order.ctx);
+}
+
+#endif /* _FANCY_CMP_H */

--- a/third_party/ccan/order/test/run-fancy.c
+++ b/third_party/ccan/order/test/run-fancy.c
@@ -1,0 +1,68 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <ccan/order/order.h>
+
+#include <ccan/tap/tap.h>
+
+#include "fancy_cmp.h"
+
+int main(int argc, char *argv[])
+{
+	struct item item1 = {
+		.value = 0,
+		.str = "aaa",
+	};
+	struct item item2 = {
+		.value = 0,
+		.str = "abb",
+	};
+	struct item item3 = {
+		.value = 0x1000,
+		.str = "baa",
+	};
+	struct cmp_info ctx1 = {
+		.xcode = 0,
+		.offset = 0,
+	};
+	struct cmp_info ctx2 = {
+		.xcode = 0x1000,
+		.offset = 1,
+	};
+	total_order(order1, struct item, struct cmp_info *) = {
+		fancy_cmp, &ctx1,
+	};
+	total_order(order2, struct item, struct cmp_info *) = {
+		fancy_cmp, &ctx2,
+	};
+
+	plan_tests(18);
+
+	ok1(total_order_cmp(order1, &item1, &item1) == 0);
+	ok1(total_order_cmp(order1, &item2, &item2) == 0);
+	ok1(total_order_cmp(order1, &item3, &item3) == 0);
+
+	ok1(total_order_cmp(order1, &item1, &item2) == -1);
+	ok1(total_order_cmp(order1, &item2, &item3) == -1);
+	ok1(total_order_cmp(order1, &item1, &item3) == -1);
+
+	ok1(total_order_cmp(order1, &item2, &item1) == 1);
+	ok1(total_order_cmp(order1, &item3, &item2) == 1);
+	ok1(total_order_cmp(order1, &item3, &item1) == 1);
+
+
+	ok1(total_order_cmp(order2, &item1, &item1) == 0);
+	ok1(total_order_cmp(order2, &item2, &item2) == 0);
+	ok1(total_order_cmp(order2, &item3, &item3) == 0);
+
+	ok1(total_order_cmp(order2, &item1, &item2) == 1);
+	ok1(total_order_cmp(order2, &item2, &item3) == 1);
+	ok1(total_order_cmp(order2, &item1, &item3) == 1);
+
+	ok1(total_order_cmp(order2, &item2, &item1) == -1);
+	ok1(total_order_cmp(order2, &item3, &item2) == -1);
+	ok1(total_order_cmp(order2, &item3, &item1) == -1);
+	
+	exit(0);
+}

--- a/third_party/ccan/ptrint/LICENSE
+++ b/third_party/ccan/ptrint/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/third_party/ccan/ptrint/_info
+++ b/third_party/ccan/ptrint/_info
@@ -1,0 +1,60 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * ptrint - Encoding integers in pointer values
+ *
+ * Library (standard or ccan) functions which take user supplied
+ * callbacks usually have the callback supplied with a void * context
+ * pointer.  For simple cases, it's sometimes sufficient to pass a
+ * simple integer cast into a void *, rather than having to allocate a
+ * context structure.  This module provides some helper macros to do
+ * this relatively safely and portably.
+ *
+ * The key characteristics of these functions are:
+ *	ptr2int(int2ptr(val)) == val
+ * and
+ *      !int2ptr(val) == !val
+ * (i.e. the transformation preserves truth value).
+ *
+ * Example:
+ *	#include <ccan/ptrint/ptrint.h>
+ *
+ *	static void callback(void *opaque)
+ *	{
+ *		int val = ptr2int(opaque);
+ *		printf("Value is %d\n", val);
+ *	}
+ *
+ *	void (*cb)(void *opaque) = callback;
+ *
+ *	int main(int argc, char *argv[])
+ *	{
+ *		int val = 17;
+ *
+ *		(*cb)(int2ptr(val));
+ *		exit(0);
+ *	}
+ *
+ * License: CC0 (Public domain)
+ * Author: David Gibson <david@gibson.dropbear.id.au>
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/build_assert\n");
+		printf("ccan/compiler\n");
+		return 0;
+	}
+	if (strcmp(argv[1], "testdepends") == 0) {
+		printf("ccan/array_size\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/third_party/ccan/ptrint/ptrint.h
+++ b/third_party/ccan/ptrint/ptrint.h
@@ -1,0 +1,35 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_PTRINT_H
+#define CCAN_PTRINT_H
+
+#include "config.h"
+
+#include <stddef.h>
+
+#include <ccan/build_assert/build_assert.h>
+#include <ccan/compiler/compiler.h>
+
+/*
+ * This is a deliberately incomplete type, because it should never be
+ * dereferenced - instead it marks pointer values which are actually
+ * encoding integers
+ */
+typedef struct ptrint ptrint_t;
+
+CONST_FUNCTION static inline ptrdiff_t ptr2int(const ptrint_t *p)
+{
+	/*
+	 * ptrdiff_t is the right size by definition, but to avoid
+	 * surprises we want a warning if the user can't fit at least
+	 * a regular int in there
+	 */
+	BUILD_ASSERT(sizeof(int) <= sizeof(ptrdiff_t));
+	return (const char *)p - (const char *)NULL;
+}
+
+CONST_FUNCTION static inline ptrint_t *int2ptr(ptrdiff_t i)
+{
+	return (ptrint_t *)((char *)NULL + i);
+}
+
+#endif /* CCAN_PTRINT_H */

--- a/third_party/ccan/ptrint/test/run.c
+++ b/third_party/ccan/ptrint/test/run.c
@@ -1,0 +1,29 @@
+#include <limits.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include <ccan/ptrint/ptrint.h>
+#include <ccan/tap/tap.h>
+
+static ptrdiff_t testvals[] = {
+	-INT_MAX, -1, 0, 1, 2, 17, INT_MAX,
+};
+
+int main(void)
+{
+	int i;
+
+	/* This is how many tests you plan to run */
+	plan_tests(2 * ARRAY_SIZE(testvals));
+
+	for (i = 0; i < ARRAY_SIZE(testvals); i++) {
+		ptrdiff_t val = testvals[i];
+		void *ptr = int2ptr(val);
+
+		ok1(ptr2int(ptr) == val);
+		ok1(!val == !ptr);
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/third_party/ccan/typesafe_cb/LICENSE
+++ b/third_party/ccan/typesafe_cb/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/third_party/ccan/typesafe_cb/_info
+++ b/third_party/ccan/typesafe_cb/_info
@@ -1,0 +1,151 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * typesafe_cb - macros for safe callbacks.
+ *
+ * The basis of the typesafe_cb header is typesafe_cb_cast(): a
+ * conditional cast macro.   If an expression exactly matches a given
+ * type, it is cast to the target type, otherwise it is left alone.
+ *
+ * This allows us to create functions which take a small number of
+ * specific types, rather than being forced to use a void *.  In
+ * particular, it is useful for creating typesafe callbacks as the
+ * helpers typesafe_cb(), typesafe_cb_preargs() and
+ * typesafe_cb_postargs() demonstrate.
+ * 
+ * The standard way of passing arguments to callback functions in C is
+ * to use a void pointer, which the callback then casts back to the
+ * expected type.  This unfortunately subverts the type checking the
+ * compiler would perform if it were a direct call.  Here's an example:
+ *
+ *	static void my_callback(void *_obj)
+ *	{
+ *		struct obj *obj = _obj;
+ *		...
+ *	}
+ *	...
+ *		register_callback(my_callback, &my_obj);
+ *
+ * If we wanted to use the natural type for my_callback (ie. "void
+ * my_callback(struct obj *obj)"), we could make register_callback()
+ * take a void * as its first argument, but this would subvert all
+ * type checking.  We really want register_callback() to accept only
+ * the exactly correct function type to match the argument, or a
+ * function which takes a void *.
+ *
+ * This is where typesafe_cb() comes in: it uses typesafe_cb_cast() to
+ * cast the callback function if it matches the argument type:
+ *
+ *	void _register_callback(void (*cb)(void *arg), void *arg);
+ *	#define register_callback(cb, arg)				\
+ *		_register_callback(typesafe_cb(void, void *, (cb), (arg)), \
+ *				   (arg))
+ *
+ * On compilers which don't support the extensions required
+ * typesafe_cb_cast() and friend become an unconditional cast, so your
+ * code will compile but you won't get type checking.
+ *
+ * Example:
+ *	#include <ccan/typesafe_cb/typesafe_cb.h>
+ *	#include <stdlib.h>
+ *	#include <stdio.h>
+ *
+ *	// Generic callback infrastructure.
+ *	struct callback {
+ *		struct callback *next;
+ *		int value;
+ *		int (*callback)(int value, void *arg);
+ *		void *arg;
+ *	};
+ *	static struct callback *callbacks;
+ *	
+ *	static void _register_callback(int value, int (*cb)(int, void *),
+ *				       void *arg)
+ *	{
+ *		struct callback *new = malloc(sizeof(*new));
+ *		new->next = callbacks;
+ *		new->value = value;
+ *		new->callback = cb;
+ *		new->arg = arg;
+ *		callbacks = new;
+ *	}
+ *	#define register_callback(value, cb, arg)			\
+ *		_register_callback(value,				\
+ *				   typesafe_cb_preargs(int, void *,	\
+ *						       (cb), (arg), int),\
+ *				   (arg))
+ *	
+ *	static struct callback *find_callback(int value)
+ *	{
+ *		struct callback *i;
+ *	
+ *		for (i = callbacks; i; i = i->next)
+ *			if (i->value == value)
+ *				return i;
+ *		return NULL;
+ *	}   
+ *
+ *	// Define several silly callbacks.  Note they don't use void *!
+ *	#define DEF_CALLBACK(name, op)			\
+ *		static int name(int val, int *arg)	\
+ *		{					\
+ *			printf("%s", #op);		\
+ *			return val op *arg;		\
+ *		}
+ *	DEF_CALLBACK(multiply, *);
+ *	DEF_CALLBACK(add, +);
+ *	DEF_CALLBACK(divide, /);
+ *	DEF_CALLBACK(sub, -);
+ *	DEF_CALLBACK(or, |);
+ *	DEF_CALLBACK(and, &);
+ *	DEF_CALLBACK(xor, ^);
+ *	DEF_CALLBACK(assign, =);
+ *
+ *	// Silly game to find the longest chain of values.
+ *	int main(int argc, char *argv[])
+ *	{
+ *		int i, run = 1, num = argv[1] ? atoi(argv[1]) : 0;
+ *	
+ *		for (i = 1; i < 1024;) {
+ *			// Since run is an int, compiler checks "add" does too.
+ *			register_callback(i++, add, &run);
+ *			register_callback(i++, divide, &run);
+ *			register_callback(i++, sub, &run);
+ *			register_callback(i++, multiply, &run);
+ *			register_callback(i++, or, &run);
+ *			register_callback(i++, and, &run);
+ *			register_callback(i++, xor, &run);
+ *			register_callback(i++, assign, &run);
+ *		}
+ *	
+ *		printf("%i ", num);
+ *		while (run < 56) {
+ *			struct callback *cb = find_callback(num % i);
+ *			if (!cb) {
+ *				printf("-> STOP\n");
+ *				return 1;
+ *			}
+ *			num = cb->callback(num, cb->arg);
+ *			printf("->%i ", num);
+ *			run++;
+ *		}
+ *		printf("-> Winner!\n");
+ *		return 0;
+ *	}
+ *
+ * License: CC0 (Public domain)
+ * Author: Rusty Russell <rusty@rustcorp.com.au>
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		return 0;
+	}
+
+	return 1;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-cast_if_type-promotable.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-cast_if_type-promotable.c
@@ -1,0 +1,23 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdbool.h>
+
+static void _set_some_value(void *val)
+{
+}
+
+#define set_some_value(expr)						\
+	_set_some_value(typesafe_cb_cast(void *, long, (expr)))
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	bool x = 0;
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	long x = 0;
+#endif
+	set_some_value(x);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb-int.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb-int.c
@@ -1,0 +1,27 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+void _callback(void (*fn)(void *arg), void *arg);
+void _callback(void (*fn)(void *arg), void *arg)
+{
+	fn(arg);
+}
+
+/* Callback is set up to warn if arg isn't a pointer (since it won't
+ * pass cleanly to _callback's second arg. */
+#define callback(fn, arg)						\
+	_callback(typesafe_cb(void, (fn), (arg)), (arg))
+
+void my_callback(int something);
+void my_callback(int something)
+{
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	/* This fails due to arg, not due to cast. */
+	callback(my_callback, 100);
+#endif
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb.c
@@ -1,0 +1,34 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+static void _register_callback(void (*cb)(void *arg), void *arg)
+{
+}
+
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb(void, void *, (cb), (arg)), (arg))
+
+static void my_callback(char *p)
+{
+}
+
+int main(int argc, char *argv[])
+{
+	char str[] = "hello world";
+#ifdef FAIL
+	int *p;
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	char *p;
+#endif
+	p = NULL;
+
+	/* This should work always. */
+	register_callback(my_callback, str);
+
+	/* This will fail with FAIL defined */
+	register_callback(my_callback, p);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_cast-multi.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_cast-multi.c
@@ -1,0 +1,43 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+struct foo {
+	int x;
+};
+
+struct bar {
+	int x;
+};
+
+struct baz {
+	int x;
+};
+
+struct any {
+	int x;
+};
+
+struct other {
+	int x;
+};
+
+static void take_any(struct any *any)
+{
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	struct other
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	struct foo
+#endif
+		*arg = NULL;
+	take_any(typesafe_cb_cast3(struct any *,
+				   struct foo *, struct bar *, struct baz *,
+				   arg));
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_cast.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_cast.c
@@ -1,0 +1,25 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+
+void _set_some_value(void *val);
+
+void _set_some_value(void *val)
+{
+}
+
+#define set_some_value(expr)						\
+	_set_some_value(typesafe_cb_cast(void *, unsigned long, (expr)))
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	int x = 0;
+	set_some_value(x);
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	void *p = 0;
+	set_some_value(p);
+#endif
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_postargs.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_postargs.c
@@ -1,0 +1,27 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+static void _register_callback(void (*cb)(void *arg, int x), void *arg)
+{
+}
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb_postargs(void, void *, (cb), (arg), int), (arg))
+
+static void my_callback(char *p, int x)
+{
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	int *p;
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	char *p;
+#endif
+	p = NULL;
+	register_callback(my_callback, p);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_preargs.c
+++ b/third_party/ccan/typesafe_cb/test/compile_fail-typesafe_cb_preargs.c
@@ -1,0 +1,28 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+static void _register_callback(void (*cb)(int x, void *arg), void *arg)
+{
+}
+
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb_preargs(void, void *, (cb), (arg), int), (arg))
+
+static void my_callback(int x, char *p)
+{
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef FAIL
+	int *p;
+#if !HAVE_TYPEOF||!HAVE_BUILTIN_CHOOSE_EXPR||!HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if typesafe_cb_cast is a noop."
+#endif
+#else
+	char *p;
+#endif
+	p = NULL;
+	register_callback(my_callback, p);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-NULL.c
+++ b/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-NULL.c
@@ -1,0 +1,17 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+/* NULL args for callback function should be OK for normal and _def. */
+
+static void _register_callback(void (*cb)(const void *arg), const void *arg)
+{
+}
+
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb(void, const void *, (cb), (arg)), (arg))
+
+int main(int argc, char *argv[])
+{
+	register_callback(NULL, "hello world");
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-undefined.c
+++ b/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-undefined.c
@@ -1,0 +1,49 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+/* const args in callbacks should be OK. */
+
+static void _register_callback(void (*cb)(void *arg), void *arg)
+{
+}
+
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb(void, void *, (cb), (arg)), (arg))
+
+static void _register_callback_pre(void (*cb)(int x, void *arg), void *arg)
+{
+}
+
+#define register_callback_pre(cb, arg)					\
+	_register_callback_pre(typesafe_cb_preargs(void, void *, (cb), (arg), int), (arg))
+
+static void _register_callback_post(void (*cb)(void *arg, int x), void *arg)
+{
+}
+
+#define register_callback_post(cb, arg)					\
+	_register_callback_post(typesafe_cb_postargs(void, void *, (cb), (arg), int), (arg))
+
+struct undefined;
+
+static void my_callback(struct undefined *undef)
+{
+}
+
+static void my_callback_pre(int x, struct undefined *undef)
+{
+}
+
+static void my_callback_post(struct undefined *undef, int x)
+{
+}
+
+int main(int argc, char *argv[])
+{
+	struct undefined *handle = NULL;
+
+	register_callback(my_callback, handle);
+	register_callback_pre(my_callback_pre, handle);
+	register_callback_post(my_callback_post, handle);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-vars.c
+++ b/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb-vars.c
@@ -1,0 +1,52 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+/* const args in callbacks should be OK. */
+
+static void _register_callback(void (*cb)(void *arg), void *arg)
+{
+}
+
+#define register_callback(cb, arg)				\
+	_register_callback(typesafe_cb(void, void *, (cb), (arg)), (arg))
+
+static void _register_callback_pre(void (*cb)(int x, void *arg), void *arg)
+{
+}
+
+#define register_callback_pre(cb, arg)					\
+	_register_callback_pre(typesafe_cb_preargs(void, void *, (cb), (arg), int), (arg))
+
+static void _register_callback_post(void (*cb)(void *arg, int x), void *arg)
+{
+}
+
+#define register_callback_post(cb, arg)					\
+	_register_callback_post(typesafe_cb_postargs(void, void *, (cb), (arg), int), (arg))
+
+struct undefined;
+
+static void my_callback(struct undefined *undef)
+{
+}
+
+static void my_callback_pre(int x, struct undefined *undef)
+{
+}
+
+static void my_callback_post(struct undefined *undef, int x)
+{
+}
+
+int main(int argc, char *argv[])
+{
+	struct undefined *handle = NULL;
+	void (*cb)(struct undefined *undef) = my_callback;
+	void (*pre)(int x, struct undefined *undef) = my_callback_pre;
+	void (*post)(struct undefined *undef, int x) = my_callback_post;
+
+	register_callback(cb, handle);
+	register_callback_pre(pre, handle);
+	register_callback_post(post, handle);
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb_cast.c
+++ b/third_party/ccan/typesafe_cb/test/compile_ok-typesafe_cb_cast.c
@@ -1,0 +1,41 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <stdlib.h>
+
+struct foo {
+	int x;
+};
+
+struct bar {
+	int x;
+};
+
+struct baz {
+	int x;
+};
+
+struct any {
+	int x;
+};
+
+static void take_any(struct any *any)
+{
+}
+
+int main(int argc, char *argv[])
+{
+	/* Otherwise we get unused warnings for these. */
+	struct foo *foo = NULL;
+	struct bar *bar = NULL;
+	struct baz *baz = NULL;
+
+	take_any(typesafe_cb_cast3(struct any *,
+				   struct foo *, struct bar *, struct baz *,
+				   foo));
+	take_any(typesafe_cb_cast3(struct any *, 
+				   struct foo *, struct bar *, struct baz *,
+				   bar));
+	take_any(typesafe_cb_cast3(struct any *, 
+				   struct foo *, struct bar *, struct baz *,
+				   baz));
+	return 0;
+}

--- a/third_party/ccan/typesafe_cb/test/run.c
+++ b/third_party/ccan/typesafe_cb/test/run.c
@@ -1,0 +1,109 @@
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <string.h>
+#include <stdint.h>
+#include <ccan/tap/tap.h>
+
+static char dummy = 0;
+
+/* The example usage. */
+static void _set_some_value(void *val)
+{
+	ok1(val == &dummy);
+}
+
+#define set_some_value(expr)						\
+	_set_some_value(typesafe_cb_cast(void *, unsigned long, (expr)))
+
+static void _callback_onearg(void (*fn)(void *arg), void *arg)
+{
+	fn(arg);
+}
+
+static void _callback_preargs(void (*fn)(int a, int b, void *arg), void *arg)
+{
+	fn(1, 2, arg);
+}
+
+static void _callback_postargs(void (*fn)(void *arg, int a, int b), void *arg)
+{
+	fn(arg, 1, 2);
+}
+
+#define callback_onearg(cb, arg)					\
+	_callback_onearg(typesafe_cb(void, void *, (cb), (arg)), (arg))
+
+#define callback_preargs(cb, arg)					\
+	_callback_preargs(typesafe_cb_preargs(void, void *, (cb), (arg), int, int), (arg))
+
+#define callback_postargs(cb, arg)					\
+	_callback_postargs(typesafe_cb_postargs(void, void *, (cb), (arg), int, int), (arg))
+
+static void my_callback_onearg(char *p)
+{
+	ok1(strcmp(p, "hello world") == 0);
+}
+
+static void my_callback_preargs(int a, int b, char *p)
+{
+	ok1(a == 1);
+	ok1(b == 2);
+	ok1(strcmp(p, "hello world") == 0);
+}
+
+static void my_callback_postargs(char *p, int a, int b)
+{
+	ok1(a == 1);
+	ok1(b == 2);
+	ok1(strcmp(p, "hello world") == 0);
+}
+
+/* This is simply a compile test; we promised typesafe_cb_cast can be in a
+ * static initializer. */
+struct callback_onearg
+{
+	void (*fn)(void *arg);
+	const void *arg;
+};
+
+struct callback_onearg cb_onearg
+= { typesafe_cb(void, void *, my_callback_onearg, (char *)(intptr_t)"hello world"),
+    "hello world" };
+
+struct callback_preargs
+{
+	void (*fn)(int a, int b, void *arg);
+	const void *arg;
+};
+
+struct callback_preargs cb_preargs
+= { typesafe_cb_preargs(void, void *, my_callback_preargs,
+			(char *)(intptr_t)"hi", int, int), "hi" };
+
+struct callback_postargs
+{
+	void (*fn)(void *arg, int a, int b);
+	const void *arg;
+};
+
+struct callback_postargs cb_postargs
+= { typesafe_cb_postargs(void, void *, my_callback_postargs, 
+			 (char *)(intptr_t)"hi", int, int), "hi" };
+
+int main(int argc, char *argv[])
+{
+	void *p = &dummy;
+	unsigned long l = (unsigned long)p;
+	char str[] = "hello world";
+
+	plan_tests(2 + 1 + 3 + 3);
+	set_some_value(p);
+	set_some_value(l);
+
+	callback_onearg(my_callback_onearg, str);
+
+	callback_preargs(my_callback_preargs, str);
+
+	callback_postargs(my_callback_postargs, str);
+
+	return exit_status();
+}

--- a/third_party/ccan/typesafe_cb/typesafe_cb.h
+++ b/third_party/ccan/typesafe_cb/typesafe_cb.h
@@ -1,0 +1,134 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_TYPESAFE_CB_H
+#define CCAN_TYPESAFE_CB_H
+#include "config.h"
+
+#if HAVE_TYPEOF && HAVE_BUILTIN_CHOOSE_EXPR && HAVE_BUILTIN_TYPES_COMPATIBLE_P
+/**
+ * typesafe_cb_cast - only cast an expression if it matches a given type
+ * @desttype: the type to cast to
+ * @oktype: the type we allow
+ * @expr: the expression to cast
+ *
+ * This macro is used to create functions which allow multiple types.
+ * The result of this macro is used somewhere that a @desttype type is
+ * expected: if @expr is exactly of type @oktype, then it will be
+ * cast to @desttype type, otherwise left alone.
+ *
+ * This macro can be used in static initializers.
+ *
+ * This is merely useful for warnings: if the compiler does not
+ * support the primitives required for typesafe_cb_cast(), it becomes an
+ * unconditional cast, and the @oktype argument is not used.  In
+ * particular, this means that @oktype can be a type which uses the
+ * "typeof": it will not be evaluated if typeof is not supported.
+ *
+ * Example:
+ *	// We can take either an unsigned long or a void *.
+ *	void _set_some_value(void *val);
+ *	#define set_some_value(e)			\
+ *		_set_some_value(typesafe_cb_cast(void *, (e), unsigned long))
+ */
+#define typesafe_cb_cast(desttype, oktype, expr)			\
+	__builtin_choose_expr(						\
+		__builtin_types_compatible_p(__typeof__(0?(expr):(expr)), \
+					     oktype),			\
+		(desttype)(expr), (expr))
+#else
+#define typesafe_cb_cast(desttype, oktype, expr) ((desttype)(expr))
+#endif
+
+/**
+ * typesafe_cb_cast3 - only cast an expression if it matches given types
+ * @desttype: the type to cast to
+ * @ok1: the first type we allow
+ * @ok2: the second type we allow
+ * @ok3: the third type we allow
+ * @expr: the expression to cast
+ *
+ * This is a convenient wrapper for multiple typesafe_cb_cast() calls.
+ * You can chain them inside each other (ie. use typesafe_cb_cast()
+ * for expr) if you need more than 3 arguments.
+ *
+ * Example:
+ *	// We can take either a long, unsigned long, void * or a const void *.
+ *	void _set_some_value(void *val);
+ *	#define set_some_value(expr)					\
+ *		_set_some_value(typesafe_cb_cast3(void *,,		\
+ *					    long, unsigned long, const void *,\
+ *					    (expr)))
+ */
+#define typesafe_cb_cast3(desttype, ok1, ok2, ok3, expr)		\
+	typesafe_cb_cast(desttype, ok1,					\
+			 typesafe_cb_cast(desttype, ok2,		\
+					  typesafe_cb_cast(desttype, ok3, \
+							   (expr))))
+
+/**
+ * typesafe_cb - cast a callback function if it matches the arg
+ * @rtype: the return type of the callback function
+ * @atype: the (pointer) type which the callback function expects.
+ * @fn: the callback function to cast
+ * @arg: the (pointer) argument to hand to the callback function.
+ *
+ * If a callback function takes a single argument, this macro does
+ * appropriate casts to a function which takes a single atype argument if the
+ * callback provided matches the @arg.
+ *
+ * It is assumed that @arg is of pointer type: usually @arg is passed
+ * or assigned to a void * elsewhere anyway.
+ *
+ * Example:
+ *	void _register_callback(void (*fn)(void *arg), void *arg);
+ *	#define register_callback(fn, arg) \
+ *		_register_callback(typesafe_cb(void, (fn), void*, (arg)), (arg))
+ */
+#define typesafe_cb(rtype, atype, fn, arg)			\
+	typesafe_cb_cast(rtype (*)(atype),			\
+			 rtype (*)(__typeof__(arg)),		\
+			 (fn))
+
+/**
+ * typesafe_cb_preargs - cast a callback function if it matches the arg
+ * @rtype: the return type of the callback function
+ * @atype: the (pointer) type which the callback function expects.
+ * @fn: the callback function to cast
+ * @arg: the (pointer) argument to hand to the callback function.
+ *
+ * This is a version of typesafe_cb() for callbacks that take other arguments
+ * before the @arg.
+ *
+ * Example:
+ *	void _register_callback(void (*fn)(int, void *arg), void *arg);
+ *	#define register_callback(fn, arg)				   \
+ *		_register_callback(typesafe_cb_preargs(void, void *,	   \
+ *				   (fn), (arg), int),			   \
+ *				   (arg))
+ */
+#define typesafe_cb_preargs(rtype, atype, fn, arg, ...)			\
+	typesafe_cb_cast(rtype (*)(__VA_ARGS__, atype),			\
+			 rtype (*)(__VA_ARGS__, __typeof__(arg)),	\
+			 (fn))
+
+/**
+ * typesafe_cb_postargs - cast a callback function if it matches the arg
+ * @rtype: the return type of the callback function
+ * @atype: the (pointer) type which the callback function expects.
+ * @fn: the callback function to cast
+ * @arg: the (pointer) argument to hand to the callback function.
+ *
+ * This is a version of typesafe_cb() for callbacks that take other arguments
+ * after the @arg.
+ *
+ * Example:
+ *	void _register_callback(void (*fn)(void *arg, int), void *arg);
+ *	#define register_callback(fn, arg) \
+ *		_register_callback(typesafe_cb_postargs(void, (fn), void *, \
+ *				   (arg), int),				    \
+ *				   (arg))
+ */
+#define typesafe_cb_postargs(rtype, atype, fn, arg, ...)		\
+	typesafe_cb_cast(rtype (*)(atype, __VA_ARGS__),			\
+			 rtype (*)(__typeof__(arg), __VA_ARGS__),	\
+			 (fn))
+#endif /* CCAN_CAST_IF_TYPE_H */


### PR DESCRIPTION
Simpler to build, and I was getting some weird valgrind errors and inconsistent results when using libjudy.  You'd think a 15-year-old library would have most of the kinks worked out of it by now!