### PR TITLE
Stop using NULL for empty traces

### DIFF
--- a/src/csp0.c
+++ b/src/csp0.c
@@ -739,13 +739,13 @@ parse_trace(struct csp0_parse_state *state, struct csp_trace **dest)
     skip_whitespace(state);
     if (parse_identifier(state, &id) != 0) {
         require(parse_token(state, close));
-        *dest = NULL;
+        *dest = csp_trace_new_empty();
         DEBUG(2, "PASS   trace");
         return 0;
     }
 
     event = csp_event_get_sized(id.start, id.length);
-    trace = csp_trace_new(event, NULL, NULL);
+    trace = csp_trace_new(event, csp_trace_new_empty());
     skip_whitespace(state);
 
     while (parse_token(state, ",") == 0) {
@@ -756,7 +756,7 @@ parse_trace(struct csp0_parse_state *state, struct csp_trace **dest)
             return -1;
         }
         event = csp_event_get_sized(id.start, id.length);
-        trace = csp_trace_new(event, NULL, trace);
+        trace = csp_trace_new(event, trace);
         skip_whitespace(state);
     }
 

--- a/src/denotational.h
+++ b/src/denotational.h
@@ -21,21 +21,33 @@
 
 /* A sequence of events.  To make them easier to construct, we represent a trace
  * as a reversed linked list, and we include a reference to the process that you
- * end up in after following the trace. */
+ * end up in after following the trace.
+ *
+ * An empty trace has `event == NULL`, and must also have `prev == NULL`.
+ * */
 struct csp_trace {
     const struct csp_event *event;
-    struct csp_process *process;
-    size_t length;
     struct csp_trace *prev;
 };
 
+struct csp_trace
+csp_trace_init(const struct csp_event *event, struct csp_trace *prev);
+
+struct csp_trace
+csp_trace_init_empty(void);
+
 struct csp_trace *
-csp_trace_new(const struct csp_event *event, struct csp_process *process,
-              struct csp_trace *prev);
+csp_trace_new(const struct csp_event *event, struct csp_trace *prev);
+
+struct csp_trace *
+csp_trace_new_empty(void);
 
 /* Frees (only) `trace`. */
 void
 csp_trace_free(struct csp_trace *trace);
+
+bool
+csp_trace_empty(const struct csp_trace *trace);
 
 /* Frees `trace` and all of its predecessors.  Don't call this if any of the
  * predecessors are shared with other traces! */

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -1117,15 +1117,15 @@ trace_factory(struct csp *csp, void *vnames)
 {
     struct string_array *names = vnames;
     size_t i;
-    struct csp_trace *prev = NULL;
+    struct csp_trace *prev = csp_trace_new_empty();
     for (i = 0; i < names->count; i++) {
         const char *event_name = names->strings[i];
         const struct csp_event *event = csp_event_get(event_name);
-        struct csp_trace *trace = csp_trace_new(event, NULL, prev);
-        test_case_cleanup_register((test_case_cleanup_f *) csp_trace_free,
-                                   trace);
+        struct csp_trace *trace = csp_trace_new(event, prev);
         prev = trace;
     }
+    test_case_cleanup_register((test_case_cleanup_f *) csp_trace_free_deep,
+                               prev);
     return prev;
 }
 

--- a/tests/test-denotational.c
+++ b/tests/test-denotational.c
@@ -15,6 +15,30 @@
 
 #define MAX_NAME_LENGTH 4096
 
+struct csp_count_trace_length {
+    struct csp_trace_event_visitor visitor;
+    size_t length;
+};
+
+static void
+csp_count_trace_length_visit(struct csp *csp,
+                             struct csp_trace_event_visitor *visitor,
+                             const struct csp_trace *trace, size_t index)
+{
+    struct csp_count_trace_length *self =
+            container_of(visitor, struct csp_count_trace_length, visitor);
+    if (!csp_trace_empty(trace)) {
+        self->length++;
+    }
+}
+
+static struct csp_count_trace_length
+csp_count_trace_length(void)
+{
+    struct csp_count_trace_length self = {{csp_count_trace_length_visit}, 0};
+    return self;
+}
+
 struct csp_collect_string {
     struct csp_name_visitor visitor;
     char str[MAX_NAME_LENGTH];
@@ -49,15 +73,14 @@ check_trace_length_(const char *filename, unsigned int line,
 {
     struct csp *csp;
     struct csp_trace *trace;
+    struct csp_count_trace_length count;
     check_alloc(csp, csp_new());
     trace = csp_trace_factory_create(csp, trace_);
-    if (expected_length == 0) {
-        check_(filename, line, trace == NULL);
-    } else {
-        check_with_msg_(filename, line, trace->length == expected_length,
-                        "Unexpected trace length: got %zu, expected %zu",
-                        trace->length, expected_length);
-    }
+    count = csp_count_trace_length();
+    csp_trace_visit_events(csp, trace, &count.visitor);
+    check_with_msg_(filename, line, count.length == expected_length,
+                    "Unexpected trace length: got %zu, expected %zu",
+                    count.length, expected_length);
     csp_free(csp);
 }
 #define check_trace_length ADD_FILE_AND_LINE(check_trace_length_)

--- a/tests/test-operators.c
+++ b/tests/test-operators.c
@@ -184,7 +184,7 @@ check_process_maximal_trace_(const char *filename, unsigned int line,
         check_with_msg_(filename, line,
                         csp_process_has_trace(csp, process, trace),
                         "Process should have trace");
-        if (trace == NULL) {
+        if (csp_trace_empty(trace)) {
             break;
         }
         trace = trace->prev;


### PR DESCRIPTION
Because I want to embed csp_traces inside of other things, which doesn't play nice with a NULL pointer being a real value.