### PR TITLE
Calculate maximal finite traces of a process

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -256,7 +256,8 @@ libtests_la_SOURCES = \
 hst_SOURCES = \
 	src/hst/has-trace.c.in \
 	src/hst/hst.c \
-	src/hst/reachable.c.in
+	src/hst/reachable.c.in \
+	src/hst/traces.c.in
 hst_LDADD = libhst.la
 
 LDADD = libhst.la libtests.la

--- a/src/denotational.h
+++ b/src/denotational.h
@@ -70,26 +70,37 @@ csp_process_has_trace(struct csp *csp, struct csp_process *process,
                       const struct csp_trace *trace);
 
 /*------------------------------------------------------------------------------
- * Trace element visitor
+ * Trace visitor
  */
 
-/* You almost certainly want to iterate through the events of a trace in the
- * "correct" order, which isn't trivial since we store them in reverse order.
- * This helper takes care of reversing the reversal for you. */
-
-struct csp_trace_event_visitor {
-    /* This will always be called first with trace == NULL and index == 0 */
-    void (*visit)(struct csp *csp, struct csp_trace_event_visitor *visitor,
-                  const struct csp_trace *trace, size_t index);
+struct csp_trace_visitor {
+    void (*visit)(struct csp *csp, struct csp_trace_visitor *visitor,
+                  const struct csp_trace *trace);
 };
 
 void
-csp_trace_event_visitor_call(struct csp *csp,
-                             struct csp_trace_event_visitor *visitor,
-                             const struct csp_trace *trace, size_t index);
+csp_trace_visitor_call(struct csp *csp, struct csp_trace_visitor *visitor,
+                       const struct csp_trace *trace);
 
+/* Prints out each trace on a separate line. */
+struct csp_print_traces {
+    struct csp_trace_visitor visitor;
+    struct csp_name_visitor *wrapped;
+};
+
+struct csp_print_traces
+csp_print_traces(struct csp_name_visitor *wrapped);
+
+/* Calls `visitor` for each prefix of `trace`, shortest first.  One use of this
+ * function is to iterate through the events of `trace` in order. */
 void
-csp_trace_visit_events(struct csp *csp, const struct csp_trace *trace,
-                       struct csp_trace_event_visitor *visitor);
+csp_trace_visit_prefixes(struct csp *csp, const struct csp_trace *trace,
+                         struct csp_trace_visitor *visitor);
+
+/* Calls `visitor` for each finite trace of `process`. */
+void
+csp_process_visit_maximal_finite_traces(struct csp *csp,
+                                        struct csp_process *process,
+                                        struct csp_trace_visitor *visitor);
 
 #endif /* HST_DENOTATIONAL_H */

--- a/src/hst/hst.c
+++ b/src/hst/hst.c
@@ -12,14 +12,17 @@
 
 #include "has-trace.c.in"
 #include "reachable.c.in"
+#include "traces.c.in"
 
 struct command {
     const char *name;
     void (*run)(int argc, char **argv);
 };
 
-static struct command commands[] = {
-        {"has-trace", has_trace}, {"reachable", reachable}, {NULL, NULL}};
+static struct command commands[] = {{"has-trace", has_trace},
+                                    {"reachable", reachable},
+                                    {"traces", traces},
+                                    {NULL, NULL}};
 
 static bool
 streq(const char *str1, const char *str2)

--- a/src/hst/traces.c.in
+++ b/src/hst/traces.c.in
@@ -6,50 +6,42 @@
  */
 
 #include <assert.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
-#include "ccan/container_of/container_of.h"
 #include "csp0.h"
+#include "denotational.h"
 #include "environment.h"
 #include "process.h"
 
-struct reachable {
-    struct csp_process_visitor visitor;
+struct count_traces {
+    struct csp_trace_visitor visitor;
     size_t count;
-    bool verbose;
 };
 
 static void
-reachable_visit(struct csp *csp, struct csp_process_visitor *visitor,
-                struct csp_process *process)
+count_traces_visit(struct csp *csp, struct csp_trace_visitor *visitor,
+                   const struct csp_trace *trace)
 {
-    struct reachable *self = container_of(visitor, struct reachable, visitor);
+    struct count_traces *self =
+            container_of(visitor, struct count_traces, visitor);
     self->count++;
-    if (self->verbose) {
-        struct csp_print_name print = csp_print_name(stdout);
-        csp_process_name(csp, process, &print.visitor);
-        printf("\n");
-    }
 }
 
-struct reachable
-reachable_init(bool verbose)
+static struct count_traces
+count_traces(void)
 {
-    struct reachable self = {{reachable_visit}, 0, verbose};
+    struct count_traces self = {{count_traces_visit}, 0};
     return self;
 }
 
 static void
-reachable(int argc, char **argv)
+traces(int argc, char **argv)
 {
     bool verbose = false;
-    const char *csp0;
+    const char *str;
     struct csp *csp;
     struct csp_process *process;
-    struct reachable reachable;
 
     static struct option options[] = {{"verbose", no_argument, 0, 'v'},
                                       {0, 0, 0, 0}};
@@ -74,27 +66,32 @@ reachable(int argc, char **argv)
     argc -= optind, argv += optind;
 
     if (argc != 1) {
-        fprintf(stderr, "Usage: hst reachable [-v] <process>\n");
+        fprintf(stderr, "Usage: hst traces [-v] <process>\n");
         exit(EXIT_FAILURE);
     }
 
     csp = csp_new();
     assert(csp != NULL);
 
-    csp0 = (argc--, *argv++);
-    process = csp_load_csp0_string(csp, csp0);
+    str = (argc--, *argv++);
+    process = csp_load_csp0_string(csp, str);
     if (process == NULL) {
         csp_free(csp);
-        fprintf(stderr, "Invalid CSP₀ process \"%s\"\n", csp0);
+        fprintf(stderr, "Invalid CSP₀ process \"%s\"\n", str);
         exit(EXIT_FAILURE);
     }
 
-    reachable = reachable_init(verbose);
-    csp_process_bfs(csp, process, &reachable.visitor);
     if (verbose) {
-        printf("Reachable processes: ");
+        struct csp_print_name print_name = csp_print_name(stdout);
+        struct csp_print_traces print_traces =
+                csp_print_traces(&print_name.visitor);
+        csp_process_visit_maximal_finite_traces(csp, process,
+                                                &print_traces.visitor);
+    } else {
+        struct count_traces count = count_traces();
+        csp_process_visit_maximal_finite_traces(csp, process, &count.visitor);
+        printf("Maximal finite traces: %zu\n", count.count);
     }
-    printf("%zu\n", reachable.count);
 
     csp_free(csp);
 }

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -1137,4 +1137,37 @@ trace_(struct string_array *names)
     return factory;
 }
 
+/* An array of ID set factories. */
+struct csp_trace_factory_array {
+    size_t count;
+    struct csp_trace_factory *traces;
+};
+
+#define traces(...)                                 \
+    CPPMAGIC_IFELSE(CPPMAGIC_NONEMPTY(__VA_ARGS__)) \
+    (traces_(LENGTH(__VA_ARGS__), __VA_ARGS__))(traces_(0, NULL))
+
+UNNEEDED
+static struct csp_trace_factory_array *
+traces_(size_t count, ...)
+{
+    size_t i;
+    size_t size = (count * sizeof(struct csp_trace_factory)) +
+                  sizeof(struct csp_trace_factory_array);
+    va_list args;
+    struct csp_trace_factory_array *array = malloc(size);
+    assert(array != NULL);
+    test_case_cleanup_register(free, array);
+    array->count = count;
+    array->traces = (void *) (array + 1);
+    va_start(args, count);
+    for (i = 0; i < count; i++) {
+        struct csp_trace_factory factory =
+                va_arg(args, struct csp_trace_factory);
+        array->traces[i] = factory;
+    }
+    va_end(args);
+    return array;
+}
+
 #endif /* TEST_CASES_H */

--- a/tests/test-denotational.c
+++ b/tests/test-denotational.c
@@ -16,14 +16,13 @@
 #define MAX_NAME_LENGTH 4096
 
 struct csp_count_trace_length {
-    struct csp_trace_event_visitor visitor;
+    struct csp_trace_visitor visitor;
     size_t length;
 };
 
 static void
-csp_count_trace_length_visit(struct csp *csp,
-                             struct csp_trace_event_visitor *visitor,
-                             const struct csp_trace *trace, size_t index)
+csp_count_trace_length_visit(struct csp *csp, struct csp_trace_visitor *visitor,
+                             const struct csp_trace *trace)
 {
     struct csp_count_trace_length *self =
             container_of(visitor, struct csp_count_trace_length, visitor);
@@ -77,7 +76,7 @@ check_trace_length_(const char *filename, unsigned int line,
     check_alloc(csp, csp_new());
     trace = csp_trace_factory_create(csp, trace_);
     count = csp_count_trace_length();
-    csp_trace_visit_events(csp, trace, &count.visitor);
+    csp_trace_visit_prefixes(csp, trace, &count.visitor);
     check_with_msg_(filename, line, count.length == expected_length,
                     "Unexpected trace length: got %zu, expected %zu",
                     count.length, expected_length);


### PR DESCRIPTION
A trace of a process is maximal if you can't add anything to the trace — either because the process can't do anything after that trace, or because it loops and repeats some suffix of the trace infinitely.