### PR TITLE
Use visitors more when build initials and afters

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -30,6 +30,22 @@ csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
 }
 
 static void
+csp_any_edges_visit(struct csp *csp, struct csp_edge_visitor *visitor,
+                    const struct csp_event *initial, struct csp_process *after)
+{
+    struct csp_any_edges *self =
+            container_of(visitor, struct csp_any_edges, visitor);
+    self->has_edges = true;
+}
+
+struct csp_any_edges
+csp_any_edges(void)
+{
+    struct csp_any_edges self = {{csp_any_edges_visit}, false};
+    return self;
+}
+
+static void
 csp_collect_afters_visit(struct csp *csp, struct csp_edge_visitor *visitor,
                          const struct csp_event *event,
                          struct csp_process *after)

--- a/src/process.h
+++ b/src/process.h
@@ -32,6 +32,14 @@ void
 csp_edge_visitor_call(struct csp *csp, struct csp_edge_visitor *visitor,
                       const struct csp_event *event, struct csp_process *after);
 
+struct csp_any_edges {
+    struct csp_edge_visitor visitor;
+    bool has_edges;
+};
+
+struct csp_any_edges
+csp_any_edges(void);
+
 struct csp_collect_afters {
     struct csp_edge_visitor visitor;
     struct csp_process_set *set;


### PR DESCRIPTION
In several of our operator implementations, we'd build something up into a set just to immediately iterate through the contents of that set.  That's overkill; we can just implement the body of that loop as a visitor and process whatever was in the set on the fly.