### PR TITLE
Add traced processes

### DIFF
--- a/src/denotational.h
+++ b/src/denotational.h
@@ -16,7 +16,7 @@
 #include "process.h"
 
 /*------------------------------------------------------------------------------
- * Denotational semantics
+ * Traces
  */
 
 /* A sequence of events.  To make them easier to construct, we represent a trace
@@ -28,6 +28,7 @@
 struct csp_trace {
     const struct csp_event *event;
     struct csp_trace *prev;
+    csp_id hash;
 };
 
 struct csp_trace
@@ -102,5 +103,26 @@ void
 csp_process_visit_maximal_finite_traces(struct csp *csp,
                                         struct csp_process *process,
                                         struct csp_trace_visitor *visitor);
+
+/*------------------------------------------------------------------------------
+ * Traced process
+ */
+
+/* Wraps `process` so that as you walk through its subprocesses, you can easily
+ * determine which minimal trace leads to the subprocess. */
+struct csp_process *
+csp_traced_process(struct csp *csp, struct csp_process *process);
+
+/* `process` must be a subprocess of a process created via csp_traced_process */
+const struct csp_trace *
+csp_traced_process_get_trace(struct csp *csp, struct csp_process *process);
+
+/* `process` must be a subprocess of a process created via csp_traced_process */
+struct csp_process *
+csp_traced_process_get_wrapped(struct csp *csp, struct csp_process *process);
+
+struct csp_process *
+csp_traced_process_new(struct csp *csp, struct csp_process *wrapped,
+                       const struct csp_trace *trace);
 
 #endif /* HST_DENOTATIONAL_H */

--- a/src/hst/reachable.c.in
+++ b/src/hst/reachable.c.in
@@ -13,6 +13,7 @@
 
 #include "ccan/container_of/container_of.h"
 #include "csp0.h"
+#include "denotational.h"
 #include "environment.h"
 #include "process.h"
 
@@ -45,23 +46,29 @@ reachable_init(bool verbose)
 static void
 reachable(int argc, char **argv)
 {
+    bool traces = false;
     bool verbose = false;
     const char *csp0;
     struct csp *csp;
     struct csp_process *process;
     struct reachable reachable;
 
-    static struct option options[] = {{"verbose", no_argument, 0, 'v'},
+    static struct option options[] = {{"traces", no_argument, 0, 't'},
+                                      {"verbose", no_argument, 0, 'v'},
                                       {0, 0, 0, 0}};
 
     while (true) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "v", options, &option_index);
+        int c = getopt_long(argc, argv, "tv", options, &option_index);
         if (c == -1) {
             break;
         }
 
         switch (c) {
+            case 't':
+                traces = true;
+                break;
+
             case 'v':
                 verbose = true;
                 break;
@@ -89,6 +96,9 @@ reachable(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    if (verbose && traces) {
+        process = csp_traced_process(csp, process);
+    }
     reachable = reachable_init(verbose);
     csp_process_bfs(csp, process, &reachable.visitor);
     if (verbose) {


### PR DESCRIPTION
I'm really liking this idea of using the process interface to model basically everything in this refinement checker.  That's worth expanding on in a blog post.  Here we're using it to keep track of what traces you follow to get to a subprocess; we'll use that to construct a counterexample during a refinement check.